### PR TITLE
Fix CI quality and scheduled validation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,17 +408,25 @@ jobs:
   # ── 9. Mutation tests (weekly schedule only) ─────────────────────────────────
   mutation-tests:
     if: github.event_name == 'schedule'
+    needs: build-guests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Download guest artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-guests-${{ github.sha }}
+      - name: Unpack guest artifacts
+        run: tar -xzf wasm-guests.tar.gz
+
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
 
       - name: Run auth mutation tests
-        run: cargo mutants --package core-host --file core-host/src/auth.rs --timeout 120
+        run: cargo mutants --package core-host --file core-host/src/auth.rs --timeout 120 --copy-target true
 
   # ── 10. Miri cwasm cache (weekly schedule only) ───────────────────────────────
   miri-cwasm-cache:

--- a/core-host/src/host_core/tests/support_and_cache.rs
+++ b/core-host/src/host_core/tests/support_and_cache.rs
@@ -356,15 +356,15 @@ pub(super) fn instance_pool_evicts_idle_entries_for_hibernation() {
 
 #[test]
 pub(super) fn cwasm_cache_deserializes_same_engine_component() {
-    let runtime = build_test_runtime(IntegrityConfig::default_sealed());
-    let component =
-        Component::new(&runtime.engine, "(component)").expect("test component should compile");
+    let engine = build_command_engine(&IntegrityConfig::default_sealed())
+        .expect("component engine should be created");
+    let component = Component::new(&engine, "(component)").expect("test component should compile");
     let compiled = component
         .serialize()
         .expect("test component should serialize to cwasm bytes");
     // SAFETY: this test deserializes bytes produced by the same Wasmtime
     // engine instance immediately above, matching the cwasm cache invariant.
-    let restored = unsafe { Component::deserialize(&runtime.engine, &compiled) }
+    let restored = unsafe { Component::deserialize(&engine, &compiled) }
         .expect("same-engine cwasm component should deserialize");
     drop(restored);
 }

--- a/systems/system-faas-ai-list-model/src/lib.rs
+++ b/systems/system-faas-ai-list-model/src/lib.rs
@@ -53,8 +53,8 @@ fn route_request(method: &str, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>)
         let info: ModelInfo = serde_json::from_slice(body)
             .map_err(|e| format!("invalid model registration payload: {e}"))?;
         let table = bindings::tachyon::mesh::kv_partition::Table::new(MODELS_TABLE);
-        let value = serde_json::to_vec(&info)
-            .map_err(|e| format!("failed to encode model info: {e}"))?;
+        let value =
+            serde_json::to_vec(&info).map_err(|e| format!("failed to encode model info: {e}"))?;
         table
             .set(&info.alias, &value)
             .map_err(|e| format!("model registry write failed: {e}"))?;
@@ -74,8 +74,8 @@ fn route_request(method: &str, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>)
 
     if method.eq_ignore_ascii_case("GET") && path == ROUTE_LIST {
         let models = list_models()?;
-        let body = serde_json::to_vec(&models)
-            .map_err(|e| format!("failed to encode model list: {e}"))?;
+        let body =
+            serde_json::to_vec(&models).map_err(|e| format!("failed to encode model list: {e}"))?;
         return Ok((200, body));
     }
 

--- a/systems/system-faas-model-broker/src/lib.rs
+++ b/systems/system-faas-model-broker/src/lib.rs
@@ -363,9 +363,12 @@ fn commit_upload(uri: &str) -> Result<String, String> {
         })?;
     }
 
-    let alias = pending
-        .alias
-        .unwrap_or_else(|| pending.expected_hash.trim_start_matches("sha256:").to_owned());
+    let alias = pending.alias.unwrap_or_else(|| {
+        pending
+            .expected_hash
+            .trim_start_matches("sha256:")
+            .to_owned()
+    });
     notify_ai_list_model(&alias);
 
     Ok(model_path.to_string_lossy().to_string())

--- a/systems/system-faas-openai-adapter/src/lib.rs
+++ b/systems/system-faas-openai-adapter/src/lib.rs
@@ -100,19 +100,12 @@ fn route_request(method: &str, path: &str) -> Result<(u16, Vec<u8>), String> {
 }
 
 fn handle_list_models() -> Result<(u16, Vec<u8>), String> {
-    let upstream = bindings::tachyon::mesh::outbound_http::send_request(
-        "GET",
-        LIST_MODELS_URL,
-        &[],
-        &[],
-    )
-    .map_err(|e| format!("failed to reach ai-list-model: {e}"))?;
+    let upstream =
+        bindings::tachyon::mesh::outbound_http::send_request("GET", LIST_MODELS_URL, &[], &[])
+            .map_err(|e| format!("failed to reach ai-list-model: {e}"))?;
 
     if upstream.status != 200 {
-        return Err(format!(
-            "ai-list-model returned status {}",
-            upstream.status
-        ));
+        return Err(format!("ai-list-model returned status {}", upstream.status));
     }
 
     let models: Vec<ModelInfo> = serde_json::from_slice(&upstream.body)
@@ -167,15 +160,16 @@ mod tests {
                 kind: "invalid_request_error",
             },
         })
-        .unwrap();
-        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        .expect("error response should serialize");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("serialized error should parse");
         assert!(parsed["error"]["message"].is_string());
     }
 
     #[test]
     fn chat_completions_returns_501() {
         let result = route_request("POST", ROUTE_CHAT_COMPLETIONS);
-        let (status, _) = result.unwrap();
+        let (status, _) = result.expect("chat completions route should return a response");
         assert_eq!(status, 501);
     }
 }


### PR DESCRIPTION
## Summary
- apply `rustfmt` to the three new FaaS system crates and remove `unwrap()` calls rejected by the CI clippy policy
- make the cwasm Miri smoke test exercise same-engine deserialization without constructing unrelated `moka` caches or pooling configuration
- provide Wasm guest artifacts to scheduled mutation tests and copy `target` into cargo-mutants scratch trees

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::unwrap_used`
- `cargo clippy -p system-faas-ai-list-model -p system-faas-model-broker -p system-faas-openai-adapter --all-targets -- -D warnings -D clippy::unwrap_used`
- `cargo test -p system-faas-ai-list-model -p system-faas-model-broker -p system-faas-openai-adapter`
- `cargo test -p core-host cwasm_cache_deserializes_same_engine_component --no-default-features`
- `cargo +nightly miri test -p core-host cwasm_cache_deserializes_same_engine_component --no-default-features` with `MIRIFLAGS=-Zmiri-disable-isolation`
- PowerShell equivalent of `scripts/validate_cross_layer.sh` (no Bash runtime installed locally)
- `cargo mutants --package core-host --file core-host/src/auth.rs --timeout 120 --copy-target true --list`

`cargo clippy --workspace --all-targets --all-features` and the local `ai-inference` check require Linux runner dependencies (`cmake`, `nasm`, `protoc`) not installed on this Windows workstation; the CI quality job installs them before execution.