### PR TITLE
feat: add all-features Docker image variant to match CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,12 @@ jobs:
             context: .
             cargo_features: "rate-limit,resiliency,mtls,secrets-vault,websockets"
             feature_tag: "-security"
+          - image_name: tachyon-mesh
+            dockerfile: ./Dockerfile
+            context: .
+            cargo_features: ""
+            cargo_all_features: "true"
+            feature_tag: "-all-features"
     steps:
       - uses: actions/checkout@v6
 
@@ -523,5 +529,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CARGO_FEATURES=${{ matrix.cargo_features }}
+            CARGO_ALL_FEATURES=${{ matrix.cargo_all_features }}
           cache-from: type=gha,scope=${{ matrix.feature_tag || 'default' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.feature_tag || 'default' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,14 @@ RUN cargo build -p guest-call-legacy --target wasm32-wasip1 --release
 RUN cargo build -p guest-loop --target wasm32-wasip1 --release
 RUN cargo build -p legacy-mock --target x86_64-unknown-linux-musl --release
 RUN cargo build -p tachyon-ui --release
-# CARGO_FEATURES is empty for the default build; pass e.g. --build-arg CARGO_FEATURES=fips
-# to produce a feature-specific image variant.
+# CARGO_FEATURES is empty for the default build; pass e.g. --build-arg CARGO_FEATURES=http3
+# to produce a feature-specific image variant, or CARGO_ALL_FEATURES=true to enable all features.
+ARG CARGO_ALL_FEATURES=""
 ARG CARGO_FEATURES=""
 RUN set -eux; \
-    if [ -n "${CARGO_FEATURES}" ]; then \
+    if [ "${CARGO_ALL_FEATURES}" = "true" ]; then \
+      cargo build -p core-host --target x86_64-unknown-linux-musl --release --all-features; \
+    elif [ -n "${CARGO_FEATURES}" ]; then \
       cargo build -p core-host --target x86_64-unknown-linux-musl --release --features "${CARGO_FEATURES}"; \
     else \
       cargo build -p core-host --target x86_64-unknown-linux-musl --release; \


### PR DESCRIPTION
The feature-matrix-tests job tests 5 variants (default, no-default, all-features, http3, security) but publish-docker-images only had 4, leaving all-features without a published Docker image.

- Add CARGO_ALL_FEATURES ARG to Dockerfile to trigger --all-features builds
- Add 5th matrix entry (feature_tag: -all-features) to publish-docker-images
- Pass CARGO_ALL_FEATURES build-arg from the workflow matrix

https://claude.ai/code/session_01JHMt18SBcbDXxyY9NDGcfC