### PR TITLE
fix: add golang-go and perl to rust-builder for all-features Docker b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     file \
+    golang-go \
     libayatana-appindicator3-dev \
     librsvg2-dev \
     libssl-dev \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxdo-dev \
     musl-tools \
     nasm \
+    perl \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
…uild

aws-lc-fips-sys (pulled in by the fips feature via --all-features) requires:
  - Go   → aws-lc/cmake/go.cmake code generation
  - Perl → find_package(Perl) in aws-lc/CMakeLists.txt

cmake and nasm were already present; only Go and Perl were missing. Mirrors the deps documented in Dockerfile.fips fips-builder stage.

https://claude.ai/code/session_01JHMt18SBcbDXxyY9NDGcfC