### PR TITLE
fix: add all-features Docker image variant and fix musl build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,8 +486,7 @@ jobs:
           - image_name: tachyon-mesh
             dockerfile: ./Dockerfile
             context: .
-            cargo_features: ""
-            cargo_all_features: "true"
+            cargo_features: "ai-inference,ebpf-loader,experimental,http3,mtls,rate-limit,resiliency,s3-persistence,secrets-vault,websockets"
             feature_tag: "-all-features"
     steps:
       - uses: actions/checkout@v6
@@ -529,6 +528,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CARGO_FEATURES=${{ matrix.cargo_features }}
-            CARGO_ALL_FEATURES=${{ matrix.cargo_all_features }}
           cache-from: type=gha,scope=${{ matrix.feature_tag || 'default' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.feature_tag || 'default' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,13 +48,10 @@ RUN cargo build -p guest-loop --target wasm32-wasip1 --release
 RUN cargo build -p legacy-mock --target x86_64-unknown-linux-musl --release
 RUN cargo build -p tachyon-ui --release
 # CARGO_FEATURES is empty for the default build; pass e.g. --build-arg CARGO_FEATURES=http3
-# to produce a feature-specific image variant, or CARGO_ALL_FEATURES=true to enable all features.
-ARG CARGO_ALL_FEATURES=""
+# to produce a feature-specific image variant.
 ARG CARGO_FEATURES=""
 RUN set -eux; \
-    if [ "${CARGO_ALL_FEATURES}" = "true" ]; then \
-      cargo build -p core-host --target x86_64-unknown-linux-musl --release --all-features; \
-    elif [ -n "${CARGO_FEATURES}" ]; then \
+    if [ -n "${CARGO_FEATURES}" ]; then \
       cargo build -p core-host --target x86_64-unknown-linux-musl --release --features "${CARGO_FEATURES}"; \
     else \
       cargo build -p core-host --target x86_64-unknown-linux-musl --release; \


### PR DESCRIPTION
## Problème

Le job `feature-matrix-tests` testait 5 variantes de features (default, no-default, all-features, http3, security) mais `publish-docker-images` n'en avait que 4 — la variante `all-features` n'avait aucune image Docker publiée.

## Changements

### `feat` — Ajout de la 5e variante Docker `all-features` (`ci.yml`)
Nouvelle entrée dans la matrice `publish-docker-images` avec `feature_tag: "-all-features"`, produisant l'image `ghcr.io/.../tachyon-mesh:latest-all-features` à chaque push sur `main`.

### `fix` — Dépendances manquantes pour `aws-lc-fips-sys` (`Dockerfile`)
Ajout de `golang-go` et `perl` dans le stage `rust-builder` :
- **Go** → requis par `aws-lc/cmake/go.cmake` pour la génération de code du module FIPS
- **Perl** → requis par `find_package(Perl)` dans `aws-lc/CMakeLists.txt`

Ces dépendances sont documentées dans `Dockerfile.fips` mais étaient absentes du `Dockerfile` standard.

### `fix` — Énumération explicite des features, exclusion de `fips` (`ci.yml` + `Dockerfile`)

`--all-features` active `fips`, qui dépend de `aws-lc-fips-sys`. Cette crate ne supporte pas la cross-compilation depuis Ubuntu (glibc) vers `x86_64-unknown-linux-musl` — `Dockerfile.fips` contourne ce problème en utilisant `rust:alpine` où musl est la libc native.

L'image `-all-features` énumère donc explicitement toutes les features **sauf `fips`** :
```
ai-inference, ebpf-loader, experimental, http3, mtls,
rate-limit, resiliency, s3-persistence, secrets-vault, websockets
```

`fips` est exclu pour deux raisons :
1. Incompatible avec la cross-compilation Ubuntu → musl (couvert par l'image `-fips`)
2. Mutuellement exclusif avec `ring` (backend TLS par défaut)

Le mécanisme `CARGO_ALL_FEATURES` ajouté temporairement est également retiré du `Dockerfile`.

## Images Docker publiées après ce PR

| Tag | Features |
|---|---|
| `latest` | `s3-persistence` |
| `latest-fips` | `fips` (via `Dockerfile.fips`) |
| `latest-http3` | `http3` |
| `latest-security` | `rate-limit,resiliency,mtls,secrets-vault,websockets` |
| `latest-all-features` | toutes sauf `fips` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHMt18SBcbDXxyY9NDGcfC)_