### PR TITLE
fix: pin Docker actions to exact patch versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Normalize image owner
         id: owner
@@ -500,7 +500,7 @@ jobs:
         run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -508,7 +508,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v6.1.0
         with:
           images: ghcr.io/${{ steps.owner.outputs.value }}/${{ matrix.image_name }}
           tags: |
@@ -519,7 +519,7 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Build and publish Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.2.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
Floating major tags (v4, v6, v7) can be force-pushed to new commits, leaving the previous SHA unavailable on codeload.github.com and causing "action could not be found" errors. Pin to exact versions:

  docker/setup-buildx-action  v4   → v4.1.0
  docker/login-action         v4   → v4.2.0
  docker/metadata-action      v6   → v6.1.0
  docker/build-push-action    v7   → v7.2.0

https://claude.ai/code/session_01JHMt18SBcbDXxyY9NDGcfC