### PR TITLE
Document spec coverage closure: prom, upload_model, dist-limiter

### DIFF
--- a/openspec/changes/spec-coverage-closure/.openspec.yaml
+++ b/openspec/changes/spec-coverage-closure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/spec-coverage-closure/design.md
+++ b/openspec/changes/spec-coverage-closure/design.md
@@ -1,0 +1,64 @@
+## Context
+
+This change is the documentation-closure output of a full OpenSpec coverage
+audit. The audit inventoried every code surface (37 WASM systems, `core-host`,
+four sibling crates, 38 WIT files, the Tachyon-UI web components, the MCP tool
+set, and the polyglot SDKs) and matched each against `openspec/specs/`, the
+active change, and the archive. Coverage was ~98%; most apparent gaps turned out
+to be specs filed under a different name — for example `system-faas-gc` is
+documented by `volume-garbage-collector`, the gitops config store by
+`distributed-control-plane` ("GitOps Multi-branching"), and the streaming WIT
+(`response-body`, `compute-stream`/`token-stream`) by the in-flight
+`openai-inference-fidelity` change.
+
+## Decision
+
+Document the three genuinely-uncovered behaviors exactly as the code behaves
+today, rather than specifying an aspirational target. These are stable, shipped
+surfaces, so the spec should describe what is.
+
+- **prom** is modeled as its own capability — consistent with the existing
+  `system-faas-openapi` and `system-faas-config-api` component capabilities —
+  rather than folded into `faas-observability`, because it is a distinct
+  deployable component with its own output contract.
+- **upload_model** extends `mcp-server`, matching the one-requirement-per-tool
+  style already used for `register_resource`, `list_resources`, and the lifecycle
+  tools.
+- **dist-limiter** extends `distributed-crdt-rate-limiter` with the observable
+  HTTP/merge contract, leaving the existing intent requirements intact.
+
+## Discrepancies handed off as code defects
+
+The audit also found four places where an existing requirement describes
+behavior the code does not implement. These are treated as code defects to fix
+(the code should converge to the spec), not as docs to rewrite, and are recorded
+here so the trail is durable:
+
+1. **metering batch semantics.** `tracing-metering` requires
+   `system-faas-metering` to batch `tachyon.telemetry.usage` events in memory and
+   flush on a periodic interval (default 60 s). The component instead appends each
+   POSTed batch synchronously to `/app/data/metering.ndjson` with no in-memory
+   accumulation and no interval flush.
+
+2. **TEE enclave delegation.** `confidential-computing-tee` requires `core-host`
+   to bypass the pooled Wasmtime engine and delegate `requires_tee` modules to a
+   hardware enclave backend. The code parses and validates the `requires_tee`
+   flag but has no enclave backend — the delegation is unimplemented.
+
+3. **cdc-broadcaster status code.** `remediation-plan` mandates HTTP `401` for the
+   fail-closed rejection until a real Biscuit verifier is wired in.
+   `system-faas-cdc-broadcaster` returns `403`.
+
+4. **buffer replay header.** `adaptive-pressure-control-and-tiered-buffering`
+   specifies the response header `x-tachyon-buffered` naming the buffering tier.
+   `system-faas-buffer` emits `x-tachyon-buffer-replay` / `x-tachyon-job-id`
+   instead.
+
+## Notes
+
+Two minor invariants are intentionally left undocumented here because they are
+hardening details rather than capability contracts: `system-faas-tde` refuses to
+operate without a valid 256-bit `TDE_KEY_HEX`, and `system-faas-metering`
+normalizes `lora_adapter_load` events into a `meter_kind: "fuel"` record. The
+dormant `wit/mesh/routing.wit` `get-primary-node` interface (defined but imported
+by no component) is also left undocumented pending its activation or removal.

--- a/openspec/changes/spec-coverage-closure/proposal.md
+++ b/openspec/changes/spec-coverage-closure/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+An OpenSpec coverage audit cross-referenced every shipped code surface — the 37
+WASM system components, `core-host`, the sibling crates, the WIT contracts, the
+Tachyon-UI web components, the MCP tools, and the SDKs — against the 137
+capability specs, the active change, and the 259 archived changes. Coverage was
+~98%: nearly every module, interface, panel, and tool already maps to a
+governing requirement. Three shipped, observable behaviors were the exception —
+they have no requirement anywhere:
+
+- **`system-faas-prom`** renders a Prometheus text exposition on every request,
+  but no spec pins the metric set or its format. The privileged telemetry-read
+  mechanism it consumes is specified (`faas-observability`); the exposition
+  contract it produces is not.
+- **`tachyon_upload_model`** is a registered, rate-limited MCP tool, yet the MCP
+  spec enumerates every other lifecycle tool and omits this one.
+- **`system-faas-dist-limiter`** has a documented *intent* (identity-scoped CRDT
+  counters, bounded fail-open) but its observable inter-node contract — the
+  `/check`, `/merge`, `/state` HTTP surface, the windowed keying, and the
+  G-counter convergence rule — is unspecified.
+
+This change documents the existing behavior as it ships so the specs match
+reality. It changes no code. Four separate spec↔code *discrepancies* surfaced by
+the same audit are handled as code defects rather than doc edits and are listed
+in `design.md` for follow-up.
+
+## What Changes
+
+- **`system-faas-prom` exposition contract (new capability).** Specifies that
+  the component reads the host telemetry snapshot through the privileged reader
+  world and renders a fixed set of nine `tachyon_*` series as Prometheus text
+  with `# TYPE` lines, returning `200` for any request.
+- **`tachyon_upload_model` MCP tool (`mcp-server`).** Specifies the tool name,
+  the required `path` argument, delegation to
+  `tachyon_client::push_large_model`, the registered tool schema, and the tight
+  per-tool rate-limit budget shared with other large mutators.
+- **Distributed limiter sync surface (`distributed-crdt-rate-limiter`).**
+  Specifies the `/check` / `/merge` / `/state` endpoints, the `{key}:{window}`
+  time-windowed keying derived from `DIST_LIMIT_WINDOW_SECONDS`, and the
+  per-(key,node) maxima merge that makes the G-counter convergent.
+
+## Capabilities
+
+### New Capabilities
+- `system-faas-prom`: the Prometheus exposition contract served by the
+  `system-faas-prom` WASM component.
+
+### Modified Capabilities
+- `mcp-server`: adds the `tachyon_upload_model` lifecycle-tool requirement.
+- `distributed-crdt-rate-limiter`: adds the limiter's HTTP sync surface,
+  time-window keying, and merge-convergence requirements (existing intent
+  requirements are unchanged).
+
+## Impact
+
+- Documentation-only: no code, dependency, WIT, or interface change. The three
+  behaviors already ship in `systems/system-faas-prom/src/lib.rs`,
+  `tachyon-mcp/src/main.rs`, and `systems/system-faas-dist-limiter/src/lib.rs`.
+- Specs affected: new `system-faas-prom`, plus deltas to `mcp-server` and
+  `distributed-crdt-rate-limiter`.
+- Out of scope, tracked separately as code defects (see `design.md`): metering
+  batch semantics, TEE enclave delegation, the cdc-broadcaster status code, and
+  the buffer replay header — each a case where an existing requirement describes
+  behavior the code does not implement.

--- a/openspec/changes/spec-coverage-closure/specs/distributed-crdt-rate-limiter/spec.md
+++ b/openspec/changes/spec-coverage-closure/specs/distributed-crdt-rate-limiter/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Distributed limiter exposes a check / merge / state HTTP surface
+The `system-faas-dist-limiter` component SHALL expose three endpoints on its `handle-request` export. `POST /check` SHALL accept a JSON body `{ "key": string }`, increment the calling node's counter for that key, and return `{ "allowed": bool, "total": number }`, where `allowed` is `total <= DIST_LIMIT` (default 100). `POST /merge` SHALL accept a remote counter snapshot, fold it into local state, and return `204`. `GET /state` SHALL return the local counter snapshot as JSON. Any other route SHALL return `404`, and a malformed `/check` or `/merge` body SHALL return `400`.
+
+#### Scenario: Check increments and reports the running total
+- **WHEN** a `POST /check` arrives with `{ "key": "203.0.113.10" }`
+- **THEN** the limiter increments the calling node's count for that key
+- **AND** returns `{ "allowed": true, "total": 1 }` while the total is within `DIST_LIMIT`
+
+#### Scenario: Over-limit checks report not allowed
+- **WHEN** the summed total for a key exceeds `DIST_LIMIT`
+- **THEN** `/check` returns `allowed: false` together with the current `total`
+
+#### Scenario: State can be pulled for gossip
+- **WHEN** a peer sends `GET /state`
+- **THEN** the limiter returns its local per-key, per-node counter snapshot as JSON
+
+### Requirement: Counters are keyed by a fixed time window
+The limiter SHALL bucket counts under the composite key `{key}:{window}`, where `window` is `unix_seconds / DIST_LIMIT_WINDOW_SECONDS` (default 60). Counts in different windows SHALL be independent, so a key's allowance resets when the window rolls over.
+
+#### Scenario: Window rollover resets the allowance
+- **WHEN** the wall clock advances past a `DIST_LIMIT_WINDOW_SECONDS` boundary
+- **THEN** new `/check` calls count against a fresh `{key}:{window}` bucket
+- **AND** the previous window's total no longer constrains the new window
+
+### Requirement: G-counter merge converges by per-node maxima
+Each counter SHALL be a grow-only CRDT mapping `key -> { node_id -> count }` in which a node only ever increments its own entry and the effective total is the sum across nodes. Merging a remote snapshot SHALL take, for each `(key, node_id)`, the maximum of the local and remote value, so that merge is commutative, associative, and idempotent and all replicas converge regardless of gossip order.
+
+#### Scenario: Merge takes the maximum per node
+- **WHEN** node A holds `{ node-a: 2 }` for a key and merges node B's `{ node-a: 1, node-b: 1 }`
+- **THEN** the merged counter is `{ node-a: 2, node-b: 1 }`
+- **AND** the effective total is `3`
+
+#### Scenario: Merge is order-independent
+- **WHEN** two replicas exchange and merge each other's snapshots in either order
+- **THEN** both converge to the same per-node maxima
+- **AND** their effective totals are equal

--- a/openspec/changes/spec-coverage-closure/specs/mcp-server/spec.md
+++ b/openspec/changes/spec-coverage-closure/specs/mcp-server/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: The MCP server exposes an upload_model tool
+The `tachyon-mcp` binary SHALL register a `tachyon_upload_model` JSON-RPC tool that accepts a required string `path` argument — an absolute local path to a model directory (weights plus `tokenizer.json`, and `config.json` for safetensors) or a single self-contained file on the MCP host — and delegates to `tachyon_client::push_large_model(path)`, returning the resulting server-side model path in the tool result content. The tool's `inputSchema` SHALL declare `required: ["path"]`, the missing-`path` case SHALL be rejected before any cluster call, and the tool SHALL be governed by the same tight per-minute rate-limit budget as other large, hash-verified mutators.
+
+#### Scenario: Upload delegates to the model broker
+- **WHEN** the MCP server receives a `tools/call` for `tachyon_upload_model` with a string `path`
+- **THEN** it calls `tachyon_client::push_large_model(path)`
+- **AND** returns the broker's server-side model path in the result content
+
+#### Scenario: Missing path is rejected before dispatch
+- **WHEN** a `tachyon_upload_model` call omits the `path` argument
+- **THEN** the server returns an invalid-params error (`-32602`) without contacting the cluster
+
+#### Scenario: Upload is rate-limited as a heavy mutator
+- **WHEN** `tachyon_upload_model` is called more often than its per-minute budget allows
+- **THEN** further calls return the rate-limited error (`-32002`) until the bucket refills

--- a/openspec/changes/spec-coverage-closure/specs/system-faas-prom/spec.md
+++ b/openspec/changes/spec-coverage-closure/specs/system-faas-prom/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: system-faas-prom exposes host telemetry as a Prometheus exposition
+The `system-faas-prom` WASM component SHALL read the host telemetry snapshot through the privileged `tachyon:mesh/telemetry-reader` world (`get-metrics`) and render it as a Prometheus text-format exposition. It SHALL respond to any inbound `handle-request` invocation with HTTP `200` and the exposition as the response body. The component itself performs no authentication and no HTTP-method filtering; restricting who may scrape the endpoint is the host's routing responsibility.
+
+#### Scenario: Metrics are rendered on request
+- **WHEN** the component receives any `handle-request` invocation
+- **THEN** it calls `telemetry_reader::get-metrics` exactly once
+- **AND** returns status `200` with a Prometheus text-format body
+
+### Requirement: Exposition covers the full host request-telemetry metric set
+The exposition SHALL emit exactly the following nine series, each immediately preceded by its `# TYPE` line and sourced from the corresponding telemetry-snapshot field:
+
+- `tachyon_requests_total` (counter) — total requests received
+- `tachyon_requests_completed_total` (counter) — requests completed
+- `tachyon_requests_error_total` (counter) — requests that errored
+- `tachyon_active_requests` (gauge) — requests currently in flight
+- `tachyon_telemetry_dropped_events_total` (counter) — telemetry events dropped
+- `tachyon_last_status` (gauge) — last observed response status code
+- `tachyon_total_duration_us_total` (counter) — cumulative end-to-end duration (µs)
+- `tachyon_total_wasm_duration_us_total` (counter) — cumulative guest execution duration (µs)
+- `tachyon_total_host_overhead_us_total` (counter) — cumulative host overhead (µs)
+
+#### Scenario: Every series carries a TYPE annotation
+- **WHEN** a scraper reads the exposition body
+- **THEN** each of the nine `tachyon_*` series is preceded by a `# TYPE <name> <counter|gauge>` line
+- **AND** each rendered value is taken from the matching telemetry-snapshot field
+
+#### Scenario: Exposition is valid with no traffic
+- **WHEN** the host has served no requests and the component is scraped
+- **THEN** every counter and gauge renders as `0`
+- **AND** the response is still a valid `200` Prometheus exposition

--- a/openspec/changes/spec-coverage-closure/tasks.md
+++ b/openspec/changes/spec-coverage-closure/tasks.md
@@ -1,0 +1,29 @@
+## 1. system-faas-prom exposition (new capability)
+
+- [x] 1.1 Record the privileged-reader dependency: the component calls
+      `telemetry_reader::get-metrics()` from the `system-faas-guest` world.
+- [x] 1.2 Specify the nine `tachyon_*` series, their `# TYPE` annotations
+      (counter/gauge), and the snapshot field each renders.
+- [x] 1.3 Specify the `200` Prometheus-text response returned for any request.
+
+## 2. tachyon_upload_model MCP tool (mcp-server)
+
+- [x] 2.1 Specify the tool name, the required `path` argument, and delegation to
+      `tachyon_client::push_large_model`.
+- [x] 2.2 Specify the registered schema (`required: ["path"]`), the pre-dispatch
+      missing-param rejection, and the tight rate-limit budget.
+
+## 3. Distributed limiter sync surface (distributed-crdt-rate-limiter)
+
+- [x] 3.1 Specify the `POST /check`, `POST /merge`, and `GET /state` endpoints
+      with their request/response bodies and status codes.
+- [x] 3.2 Specify the `{key}:{window}` time-window keying derived from
+      `DIST_LIMIT_WINDOW_SECONDS`.
+- [x] 3.3 Specify the per-(key,node) maxima merge that makes the G-counter
+      convergent across nodes.
+
+## 4. Verification
+
+- [x] 4.1 Confirm every new requirement matches current code behavior, not an
+      aspirational target.
+- [x] 4.2 Confirm no code, dependency, or WIT change is implied by this change.


### PR DESCRIPTION
## Summary

This change closes the OpenSpec coverage audit by documenting three shipped, observable behaviors that previously had no governing specifications. The audit found ~98% coverage across 37 WASM systems, core-host, WIT files, web components, MCP tools, and SDKs; these three gaps are now documented as they exist in production code.

## Changes

- **New capability: `system-faas-prom`** — Documents the Prometheus text-format exposition contract served by the `system-faas-prom` component, including the nine `tachyon_*` series, their `# TYPE` annotations, and the privileged telemetry-reader dependency.

- **Extended capability: `mcp-server`** — Adds the `tachyon_upload_model` MCP tool specification, including the required `path` argument, delegation to `tachyon_client::push_large_model`, schema validation, and rate-limiting as a heavy mutator.

- **Extended capability: `distributed-crdt-rate-limiter`** — Specifies the HTTP sync surface (`POST /check`, `POST /merge`, `GET /state`), the `{key}:{window}` time-window keying derived from `DIST_LIMIT_WINDOW_SECONDS`, and the G-counter merge semantics (per-node maxima) that ensure convergence across nodes.

## Implementation Details

- **Documentation-only change**: No code, dependencies, WIT interfaces, or exports are modified. All three behaviors already ship in production.
- **Design rationale**: Each behavior is documented exactly as the code implements it today, not as an aspirational target, since these are stable shipped surfaces.
- **Defects tracked separately**: The audit also identified four spec↔code discrepancies (metering batch semantics, TEE enclave delegation, cdc-broadcaster status code, buffer replay header) that are recorded in `design.md` as code defects to fix rather than documentation to rewrite.

## Files Added

- `proposal.md` — Audit findings and rationale for the three new/extended specs
- `design.md` — Detailed decision notes and four code defects identified for follow-up
- `tasks.md` — Verification checklist confirming alignment with current code
- `specs/system-faas-prom/spec.md` — Prometheus exposition contract
- `specs/mcp-server/spec.md` — Upload model tool specification
- `specs/distributed-crdt-rate-limiter/spec.md` — Distributed limiter sync surface
- `.openspec.yaml` — Change metadata

https://claude.ai/code/session_01DBJxNxC2oYwjQSph9aip38