### PR TITLE
docs(openspec): extend spec-coverage-closure with TEE backend and met…

### DIFF
--- a/openspec/changes/spec-coverage-closure/design.md
+++ b/openspec/changes/spec-coverage-closure/design.md
@@ -1,58 +1,67 @@
 ## Context
 
 This change is the documentation-closure output of a full OpenSpec coverage
-audit. The audit inventoried every code surface (37 WASM systems, `core-host`,
-four sibling crates, 38 WIT files, the Tachyon-UI web components, the MCP tool
-set, and the polyglot SDKs) and matched each against `openspec/specs/`, the
-active change, and the archive. Coverage was ~98%; most apparent gaps turned out
-to be specs filed under a different name — for example `system-faas-gc` is
-documented by `volume-garbage-collector`, the gitops config store by
-`distributed-control-plane` ("GitOps Multi-branching"), and the streaming WIT
-(`response-body`, `compute-stream`/`token-stream`) by the in-flight
+audit (and a follow-up re-audit after the discrepancy fixes landed). The audit
+inventoried every code surface (37 WASM systems, `core-host`, four sibling
+crates, 38 WIT files, the Tachyon-UI web components, the MCP tool set, and the
+polyglot SDKs) and matched each against `openspec/specs/`, the active change, and
+the archive. Coverage was ~98%; most apparent gaps turned out to be specs filed
+under a different name — for example `system-faas-gc` is documented by
+`volume-garbage-collector`, the gitops config store by `distributed-control-plane`
+("GitOps Multi-branching"), and the streaming WIT by the in-flight
 `openai-inference-fidelity` change.
 
 ## Decision
 
-Document the three genuinely-uncovered behaviors exactly as the code behaves
-today, rather than specifying an aspirational target. These are stable, shipped
-surfaces, so the spec should describe what is.
+Document the genuinely-uncovered behaviors exactly as the code behaves today,
+rather than specifying an aspirational target. These are stable, shipped surfaces.
 
 - **prom** is modeled as its own capability — consistent with the existing
   `system-faas-openapi` and `system-faas-config-api` component capabilities —
-  rather than folded into `faas-observability`, because it is a distinct
-  deployable component with its own output contract.
+  rather than folded into `faas-observability`.
 - **upload_model** extends `mcp-server`, matching the one-requirement-per-tool
-  style already used for `register_resource`, `list_resources`, and the lifecycle
-  tools.
+  style already used for `register_resource` and the lifecycle tools.
 - **dist-limiter** extends `distributed-crdt-rate-limiter` with the observable
   HTTP/merge contract, leaving the existing intent requirements intact.
+- **TEE** extends `confidential-computing-tee` with the concrete backend contract.
+  The `LocalEnclave` mode is documented honestly as a non-confidential, local /
+  development path (it runs on the standard engine and only annotates the
+  response); the hardware-confidentiality guarantee applies only to the Enarx
+  Keep path. This avoids the spec over-claiming hardware isolation for a mode that
+  provides none.
+- **metering** modifies the existing `tracing-metering` requirement so the host
+  exporter — not `system-faas-metering` — owns the in-memory aggregation and the
+  size/interval flush, and adds a requirement for the durable `metering_outbox`
+  staging. The new requirements claim only what the code guarantees: durable
+  staging before export, deletion on success, and retention on failure. They do
+  **not** claim automatic re-export of retained entries (see follow-up below).
 
-## Discrepancies handed off as code defects
+## Discrepancies fixed in PR #141
 
-The audit also found four places where an existing requirement describes
-behavior the code does not implement. These are treated as code defects to fix
-(the code should converge to the spec), not as docs to rewrite, and are recorded
-here so the trail is durable:
+The audit's first pass flagged four places where an existing requirement
+described behavior the code did not implement. These were filed as code defects
+(issues #135–#138) and fixed in PR #141:
 
-1. **metering batch semantics.** `tracing-metering` requires
-   `system-faas-metering` to batch `tachyon.telemetry.usage` events in memory and
-   flush on a periodic interval (default 60 s). The component instead appends each
-   POSTed batch synchronously to `/app/data/metering.ndjson` with no in-memory
-   accumulation and no interval flush.
+1. **cdc-broadcaster status** (#135) — now returns `401` (was `403`). The
+   `remediation-plan` spec was already correct; no doc change needed.
+2. **buffer replay header** (#136) — now emits `x-tachyon-buffered` with the
+   serving tier. The `adaptive-pressure-control-and-tiered-buffering` spec was
+   already correct; no doc change needed.
+3. **metering flush** (#137) — a host-side exporter now batches and flushes on a
+   60 s interval. This introduced the exporter-ownership and durable-outbox
+   surfaces documented by the `tracing-metering` delta in this change.
+4. **TEE delegation** (#138) — `requires_tee` routes now delegate to the
+   configured backend. This introduced the backend contract documented by the
+   `confidential-computing-tee` delta in this change.
 
-2. **TEE enclave delegation.** `confidential-computing-tee` requires `core-host`
-   to bypass the pooled Wasmtime engine and delegate `requires_tee` modules to a
-   hardware enclave backend. The code parses and validates the `requires_tee`
-   flag but has no enclave backend — the delegation is unimplemented.
+## Follow-up not covered here
 
-3. **cdc-broadcaster status code.** `remediation-plan` mandates HTTP `401` for the
-   fail-closed rejection until a real Biscuit verifier is wired in.
-   `system-faas-cdc-broadcaster` returns `403`.
-
-4. **buffer replay header.** `adaptive-pressure-control-and-tiered-buffering`
-   specifies the response header `x-tachyon-buffered` naming the buffering tier.
-   `system-faas-buffer` emits `x-tachyon-buffer-replay` / `x-tachyon-job-id`
-   instead.
+- **Metering outbox drain/retry is not wired.** Retained `metering_outbox`
+  entries are durable but there is currently no sweeper that re-exports them
+  (unlike `AuthzPurgeOutbox` and `ConfigUpdateOutbox`, which have steady-cadence
+  drains in `supervisors.rs`). The `tracing-metering` delta therefore documents
+  durability and retention only, not automatic recovery. Wiring a drain is a
+  code follow-up, out of scope for this documentation change.
 
 ## Notes
 

--- a/openspec/changes/spec-coverage-closure/proposal.md
+++ b/openspec/changes/spec-coverage-closure/proposal.md
@@ -2,16 +2,14 @@
 
 An OpenSpec coverage audit cross-referenced every shipped code surface — the 37
 WASM system components, `core-host`, the sibling crates, the WIT contracts, the
-Tachyon-UI web components, the MCP tools, and the SDKs — against the 137
-capability specs, the active change, and the 259 archived changes. Coverage was
-~98%: nearly every module, interface, panel, and tool already maps to a
-governing requirement. Three shipped, observable behaviors were the exception —
-they have no requirement anywhere:
+Tachyon-UI web components, the MCP tools, and the SDKs — against the capability
+specs, the active change, and the archived changes. Coverage was ~98%. This
+change documents the behaviors that had no governing requirement.
+
+The first pass found three shipped surfaces with no requirement anywhere:
 
 - **`system-faas-prom`** renders a Prometheus text exposition on every request,
-  but no spec pins the metric set or its format. The privileged telemetry-read
-  mechanism it consumes is specified (`faas-observability`); the exposition
-  contract it produces is not.
+  but no spec pins the metric set or its format.
 - **`tachyon_upload_model`** is a registered, rate-limited MCP tool, yet the MCP
   spec enumerates every other lifecycle tool and omits this one.
 - **`system-faas-dist-limiter`** has a documented *intent* (identity-scoped CRDT
@@ -19,25 +17,42 @@ they have no requirement anywhere:
   `/check`, `/merge`, `/state` HTTP surface, the windowed keying, and the
   G-counter convergence rule — is unspecified.
 
-This change documents the existing behavior as it ships so the specs match
-reality. It changes no code. Four separate spec↔code *discrepancies* surfaced by
-the same audit are handled as code defects rather than doc edits and are listed
-in `design.md` for follow-up.
+A follow-up pass after the discrepancy fixes landed (PR #141 closed issues
+#135–#138) found that fixing two of them introduced new observable surfaces that
+are themselves undocumented:
+
+- **TEE delegation** is now implemented: `requires_tee` routes dispatch to a
+  configured `tee_backend` (`LocalEnclave` or `Enarx { keep_endpoint }`) with a
+  Keep invocation protocol and `x-tachyon-runtime` / `x-tachyon-tee-backend`
+  response annotations. The spec only described delegation at a high level.
+- **Host metering exporter + durable outbox**: the host exporter now owns the
+  in-memory aggregation and the periodic (60 s) / batch-size flush, staging each
+  batch in a durable `metering_outbox` before forwarding to `system-faas-metering`.
+  The `tracing-metering` requirement still attributed in-memory batching to
+  `system-faas-metering`.
+
+This change documents all of the above as the code behaves today. It changes no
+code.
 
 ## What Changes
 
-- **`system-faas-prom` exposition contract (new capability).** Specifies that
-  the component reads the host telemetry snapshot through the privileged reader
-  world and renders a fixed set of nine `tachyon_*` series as Prometheus text
-  with `# TYPE` lines, returning `200` for any request.
+- **`system-faas-prom` exposition contract (new capability).** Specifies the
+  privileged telemetry read and the fixed set of nine `tachyon_*` series rendered
+  as Prometheus text with `# TYPE` lines, returning `200` for any request.
 - **`tachyon_upload_model` MCP tool (`mcp-server`).** Specifies the tool name,
-  the required `path` argument, delegation to
-  `tachyon_client::push_large_model`, the registered tool schema, and the tight
-  per-tool rate-limit budget shared with other large mutators.
+  the required `path` argument, delegation to `tachyon_client::push_large_model`,
+  the registered schema, and the rate-limit budget.
 - **Distributed limiter sync surface (`distributed-crdt-rate-limiter`).**
   Specifies the `/check` / `/merge` / `/state` endpoints, the `{key}:{window}`
-  time-windowed keying derived from `DIST_LIMIT_WINDOW_SECONDS`, and the
-  per-(key,node) maxima merge that makes the G-counter convergent.
+  time-windowed keying, and the per-(key,node) maxima merge.
+- **TEE backend contract (`confidential-computing-tee`).** Specifies backend
+  selection and the `503` fail-closed path, the `LocalEnclave` (no hardware
+  isolation) vs `Enarx` Keep distinction, the Keep invocation protocol, and the
+  TEE response-annotation headers.
+- **Metering exporter ownership + durable outbox (`tracing-metering`).**
+  Realigns the existing requirement so the host exporter owns the in-memory
+  aggregation and size/interval flush, and adds the durable `metering_outbox`
+  staging (persist-before-export, delete-on-success, retain-on-failure).
 
 ## Capabilities
 
@@ -48,17 +63,25 @@ in `design.md` for follow-up.
 ### Modified Capabilities
 - `mcp-server`: adds the `tachyon_upload_model` lifecycle-tool requirement.
 - `distributed-crdt-rate-limiter`: adds the limiter's HTTP sync surface,
-  time-window keying, and merge-convergence requirements (existing intent
-  requirements are unchanged).
+  time-window keying, and merge-convergence requirements.
+- `confidential-computing-tee`: adds the concrete backend-selection, Enarx Keep
+  protocol, and response-annotation requirements.
+- `tracing-metering`: realigns the metering-aggregation ownership to the host
+  exporter and adds the durable metering-outbox requirement.
 
 ## Impact
 
-- Documentation-only: no code, dependency, WIT, or interface change. The three
-  behaviors already ship in `systems/system-faas-prom/src/lib.rs`,
-  `tachyon-mcp/src/main.rs`, and `systems/system-faas-dist-limiter/src/lib.rs`.
-- Specs affected: new `system-faas-prom`, plus deltas to `mcp-server` and
-  `distributed-crdt-rate-limiter`.
-- Out of scope, tracked separately as code defects (see `design.md`): metering
-  batch semantics, TEE enclave delegation, the cdc-broadcaster status code, and
-  the buffer replay header — each a case where an existing requirement describes
-  behavior the code does not implement.
+- Documentation-only: no code, dependency, WIT, or interface change. The behaviors
+  ship in `systems/system-faas-prom/src/lib.rs`, `tachyon-mcp/src/main.rs`,
+  `systems/system-faas-dist-limiter/src/lib.rs`, and — after PR #141 —
+  `core-host/src/host_core/app_runtime.rs` (TEE delegation + metering exporter),
+  `core-host/src/host_core/constants.rs`, and `core-host/src/store/mod.rs`
+  (`MeteringOutbox`).
+- Specs affected: new `system-faas-prom`; deltas to `mcp-server`,
+  `distributed-crdt-rate-limiter`, `confidential-computing-tee`, and
+  `tracing-metering`.
+- The four spec↔code discrepancies the audit originally flagged
+  (cdc-broadcaster `401`, buffer `x-tachyon-buffered`, metering flush, TEE
+  delegation) were fixed in code by PR #141; the cdc-broadcaster and buffer fixes
+  brought the code into line with specs that were already correct, so they need no
+  new documentation here.

--- a/openspec/changes/spec-coverage-closure/specs/confidential-computing-tee/spec.md
+++ b/openspec/changes/spec-coverage-closure/specs/confidential-computing-tee/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: TEE delegation selects the configured backend or fails closed
+When a route is flagged `requires_tee: true`, `core-host` SHALL dispatch the request to the backend named by the sealed `tee_backend` configuration. If no `tee_backend` is configured, the host SHALL fail closed with HTTP `503 Service Unavailable` rather than silently running the module on the pooled engine. Two backends SHALL be supported:
+
+- `LocalEnclave` — runs the guest on the host's standard engine and annotates the response as TEE-served. This mode provides **no hardware memory encryption** and is intended for nodes without enclave hardware (development and local testing); the hardware-confidentiality guarantee of "Core host delegates TEE-flagged modules to a hardware enclave backend" applies only to the Enarx backend.
+- `Enarx { keep_endpoint }` — delegates execution to an external Enarx Keep, gated behind the `enarx` Cargo feature and SGX/SEV-SNP hardware.
+
+#### Scenario: Missing backend fails closed
+- **WHEN** a request targets a `requires_tee` route and no `tee_backend` is configured
+- **THEN** the host returns `503 Service Unavailable`
+- **AND** the module is not executed on the pooled engine
+
+#### Scenario: Local backend runs on the standard engine
+- **WHEN** `tee_backend` is `LocalEnclave` and a `requires_tee` route is invoked
+- **THEN** the host executes the guest on its standard engine off the async runtime
+- **AND** annotates the response as served by the `local-enclave` backend
+
+### Requirement: Enarx backend executes guests over a Keep endpoint
+For the `Enarx` backend, the host SHALL POST a JSON invocation — module, route path, method, URI, headers, body, trailers, and trace id — to the configured `keep_endpoint`, and SHALL reconstruct the guest response from the Keep's JSON reply (status, headers, body, trailers, fuel consumed). A non-success HTTP status from the Keep, or an undecodable reply, SHALL surface as an internal execution error rather than a partial response.
+
+#### Scenario: Keep round-trip produces the guest response
+- **WHEN** the Enarx backend is invoked for a `requires_tee` route
+- **THEN** the host POSTs the encoded invocation to `keep_endpoint`
+- **AND** maps the Keep's structured reply into the guest HTTP response (status, headers, body, trailers) and fuel accounting
+
+#### Scenario: Keep failure is not masked
+- **WHEN** the Keep endpoint returns a non-2xx status or an undecodable body
+- **THEN** the host raises an internal execution error
+- **AND** does not return a partially populated response to the client
+
+### Requirement: TEE-delegated responses are annotated with runtime headers
+Every response produced through a TEE backend SHALL carry `x-tachyon-runtime: tee-{backend}` and `x-tachyon-tee-backend: {backend}` (`local-enclave` or `enarx`), replacing any same-named headers supplied by the guest or upstream Keep so the runtime annotation is authoritative.
+
+#### Scenario: Backend identity is stamped on the response
+- **WHEN** a `requires_tee` route is served through any TEE backend
+- **THEN** the response carries `x-tachyon-tee-backend` naming the backend
+- **AND** carries `x-tachyon-runtime` set to `tee-{backend}`
+- **AND** any client- or Keep-supplied values for those two headers are discarded

--- a/openspec/changes/spec-coverage-closure/specs/tracing-metering/spec.md
+++ b/openspec/changes/spec-coverage-closure/specs/tracing-metering/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: system-faas-metering aggregates usage events in the background
+The host's background metering exporter SHALL own the in-memory aggregation of usage events: it accumulates `tachyon.telemetry.usage` records drained from the bounded telemetry queue and flushes a batch either when the batch reaches the configured size (`TELEMETRY_EXPORT_BATCH_SIZE`) or when the periodic flush interval elapses (`TELEMETRY_EXPORT_FLUSH_INTERVAL`, default 60 seconds), whichever comes first. The exporter SHALL forward each flushed batch to `system-faas-metering`, which SHALL operate strictly as the out-of-band persistence sink (appending the billing records to durable storage) and SHALL NOT back-pressure the request path.
+
+#### Scenario: Batch flushes on size or interval
+- **WHEN** the exporter has accumulated one or more usage records
+- **THEN** it flushes once the batch reaches `TELEMETRY_EXPORT_BATCH_SIZE`
+- **AND** it also flushes a non-empty batch when the flush interval (default 60 s) elapses
+- **AND** flushing forwards the batch to `system-faas-metering` off the request path
+
+#### Scenario: Downstream outage does not back-pressure requests
+- **WHEN** a metering forward fails because the sink is temporarily unavailable
+- **THEN** the exporter continues draining and flushing subsequent batches on each interval
+- **AND** the host's request latency remains unaffected
+
+## ADDED Requirements
+
+### Requirement: Metering batches are durably staged before export
+Before forwarding a metering batch, the host SHALL persist each record to the durable `metering_outbox` store. On a successful forward it SHALL delete those staged entries; on a failed forward the entries SHALL be retained so that no usage record is lost to a host crash or a downstream outage.
+
+#### Scenario: Records survive a crash between staging and export
+- **WHEN** the host persists a metering batch to the outbox and then crashes before the forward completes
+- **THEN** the staged records remain in the `metering_outbox` table after restart
+
+#### Scenario: Successful export clears the outbox; failure retains it
+- **WHEN** a metering batch is forwarded successfully
+- **THEN** the host deletes the corresponding `metering_outbox` entries
+- **AND** a failed forward instead retains those entries durably for recovery

--- a/openspec/changes/spec-coverage-closure/tasks.md
+++ b/openspec/changes/spec-coverage-closure/tasks.md
@@ -22,8 +22,28 @@
 - [x] 3.3 Specify the per-(key,node) maxima merge that makes the G-counter
       convergent across nodes.
 
-## 4. Verification
+## 4. TEE backend contract (confidential-computing-tee)
 
-- [x] 4.1 Confirm every new requirement matches current code behavior, not an
+- [x] 4.1 Specify backend selection from the sealed `tee_backend` and the `503`
+      fail-closed path when none is configured.
+- [x] 4.2 Specify the `LocalEnclave` (no hardware isolation) vs `Enarx`
+      (`enarx` feature, Keep endpoint) distinction.
+- [x] 4.3 Specify the Enarx Keep invocation protocol and the
+      `x-tachyon-runtime` / `x-tachyon-tee-backend` response annotations.
+
+## 5. Metering exporter ownership + durable outbox (tracing-metering)
+
+- [x] 5.1 Realign the metering-aggregation requirement to the host exporter
+      (in-memory batching + size / `TELEMETRY_EXPORT_FLUSH_INTERVAL` flush).
+- [x] 5.2 Specify the durable `metering_outbox` staging: persist before export,
+      delete on success, retain on failure.
+- [x] 5.3 Keep the requirements within what the code guarantees — no claim of
+      automatic re-export of retained entries.
+
+## 6. Verification
+
+- [x] 6.1 Confirm every new requirement matches current code behavior, not an
       aspirational target.
-- [x] 4.2 Confirm no code, dependency, or WIT change is implied by this change.
+- [x] 6.2 Confirm no code, dependency, or WIT change is implied by this change.
+- [x] 6.3 Confirm the `tracing-metering` MODIFIED requirement keeps the exact
+      original title so archiving replaces it cleanly.


### PR DESCRIPTION
…ering outbox

A post-#141 re-audit found that fixing the TEE delegation (#138) and metering flush (#137) discrepancies introduced new observable surfaces with no governing requirement. Extends the spec-coverage-closure change to document them:

- confidential-computing-tee: backend selection + 503 fail-closed, LocalEnclave (no hardware isolation) vs Enarx Keep, the Keep invocation protocol, and the x-tachyon-runtime / x-tachyon-tee-backend response annotations
- tracing-metering: realigns in-memory aggregation ownership to the host exporter (size / 60s flush) and adds the durable metering_outbox staging (persist-before-export, delete-on-success, retain-on-failure)

Documentation only; no code change. The MODIFIED metering requirement keeps its exact title so archiving replaces it cleanly. Proposal/design/tasks updated.

https://claude.ai/code/session_01DBJxNxC2oYwjQSph9aip38