### PR TITLE
Fix Rust toolchain version in FIPS Docker build

### DIFF
--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -95,6 +95,15 @@ RUN cargo install cargo-chef --locked
 
 WORKDIR /workspace
 
+# The rust:alpine3.20 tag is frozen at rustc 1.94.1, but the workspace pins
+# 1.96.0 (rust-toolchain.toml) and dependencies such as sysinfo 0.39 require
+# rustc >= 1.95. Copy the toolchain file before the dependency cook so rustup
+# installs and uses the pinned toolchain in this stage too — the cook runs
+# before `COPY . .`, so without this it would silently fall back to the image's
+# default 1.94.1. We stay on Alpine 3.20 (GCC 13) for the aws-lc-fips-sys
+# delocator compatibility documented above.
+COPY rust-toolchain.toml .
+
 # Reuse the recipe extracted on the Ubuntu side (recipe.json is OS-independent)
 # so the FIPS dependency cook is keyed on Cargo.toml/Cargo.lock too.
 COPY --from=planner /workspace/recipe.json recipe.json


### PR DESCRIPTION
## Summary
This change ensures the FIPS Docker build uses the correct pinned Rust toolchain version by copying `rust-toolchain.toml` before the dependency cook stage.

## Key Changes
- Added `COPY rust-toolchain.toml .` in the FIPS Dockerfile before the dependency cook step
- This ensures rustup installs and uses the pinned Rust 1.96.0 toolchain during the cook stage, rather than silently falling back to the Alpine image's default 1.94.1

## Implementation Details
The rust:alpine3.20 base image is frozen at rustc 1.94.1, but the workspace pins 1.96.0 via `rust-toolchain.toml`. Dependencies like sysinfo 0.39 require rustc >= 1.95. Since the dependency cook runs before `COPY . .`, the toolchain file must be copied earlier to ensure the correct version is used during that stage. The Alpine 3.20 base (with GCC 13) is maintained for aws-lc-fips-sys delocator compatibility.

https://claude.ai/code/session_012VJWRYwVtiT8a2guLkbjer