### PR TITLE
fix(mutation-tests): raise cargo-mutants test timeout to 300s

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -105,7 +105,7 @@ jobs:
             --sharding round-robin \
             --jobs 2 \
             --baseline skip \
-            --timeout 120 \
+            --timeout 300 \
             --copy-target true \
             --output "mutants-auth-shard-${{ matrix.id }}"
 


### PR DESCRIPTION
## Problem

Run [27567921657](https://github.com/astorise/Tachyon-Mesh/actions/runs/27567921657) failed: every auth-mutation shard reported `TIMEOUT` for all viable mutants — including trivial mutations (`String::new()`, `Default::default()`, operator swaps) that cannot possibly hang.

## Root cause

- The baseline `core-host` test suite runs in **~48.5s** single-threaded.
- The shards run with `--jobs 2`, so two test processes contend for CPU; each run stretches toward **~100s**, plus extra test binaries and CI variance.
- That consistently exceeded the hand-set `--timeout 120`, so viable mutants timed out at exactly 120s instead of being classified caught/missed.
- `--baseline skip` disables cargo-mutants' auto timeout (normally `baseline × 5 ≈ 240s`), so the explicit `--timeout` must carry the headroom itself.

## Fix

Raise `--timeout` from 120 to **300s** — comfortably above the contended baseline and in line with what auto-detection would have chosen. None of these mutants are genuine hangs, so the 75-minute job budget is unaffected (viable mutants now finish their ~100s test run instead of burning the full timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)