### PR TITLE
fix(core-host): stop manifest hot-reload loop on filesystem access events

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # The two image builds plus the k3d/containerd image imports below are
+      # disk-heavy and have intermittently exhausted the ~14 GB free on
+      # ubuntu-latest runners ("No space left on device"). Reclaim the large
+      # preinstalled toolchains this job never uses before building.
+      - name: Free up disk space
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 

--- a/core-host/src/host_core/supervisors.rs
+++ b/core-host/src/host_core/supervisors.rs
@@ -33,8 +33,20 @@ pub(crate) const MANIFEST_FILE_WATCHER_DEBOUNCE: Duration = Duration::from_milli
 /// (a `/admin/manifest` update *writes* it), and on some filesystems every read —
 /// including the periodic S3 backup flush reading `integrity.lock` — emits one;
 /// reacting to those re-armed the watcher into an infinite reload loop.
+///
+/// The one access event that *is* a mutation signal is `Close(Write)` (inotify's
+/// `IN_CLOSE_WRITE`): a writer that finished an in-place write. We keep it so an
+/// in-place edit still triggers a reload even if the earlier `Modify` fired while
+/// the file was still incomplete. This cannot re-arm the loop because the only
+/// reader in play (the S3 backup flush) opens the manifest read-only and never
+/// emits `Close(Write)`.
 fn watcher_event_is_ignorable(kind: &notify::EventKind) -> bool {
-    matches!(kind, notify::EventKind::Access(_))
+    use notify::event::{AccessKind, AccessMode};
+    match kind {
+        notify::EventKind::Access(AccessKind::Close(AccessMode::Write)) => false,
+        notify::EventKind::Access(_) => true,
+        _ => false,
+    }
 }
 
 /// Spawn a file watcher that triggers a hot reload whenever the integrity manifest is
@@ -940,17 +952,35 @@ mod tests {
     fn watcher_ignores_access_events_but_not_writes() {
         use notify::event::{AccessKind, AccessMode, CreateKind, ModifyKind, RemoveKind};
         use notify::EventKind;
-        // The exact event the WSL2/k3s `local-path` PVC emits on every read of the
-        // manifest (e.g. the S3 backup flush) — must NOT trigger a reload.
-        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Open(
-            AccessMode::Any
-        ))));
-        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Read)));
-        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Any)));
+        // Non-mutating access — the events the WSL2/k3s `local-path` PVC emits on
+        // every read of the manifest (e.g. the S3 backup flush) — must NOT reload.
+        assert!(watcher_event_is_ignorable(&EventKind::Access(
+            AccessKind::Open(AccessMode::Any)
+        )));
+        assert!(watcher_event_is_ignorable(&EventKind::Access(
+            AccessKind::Read
+        )));
+        assert!(watcher_event_is_ignorable(&EventKind::Access(
+            AccessKind::Any
+        )));
+        assert!(watcher_event_is_ignorable(&EventKind::Access(
+            AccessKind::Close(AccessMode::Read)
+        )));
+        // `Close(Write)` (IN_CLOSE_WRITE) is a completed in-place write — it MUST
+        // still trigger a reload (a reader never emits it, so no loop risk).
+        assert!(!watcher_event_is_ignorable(&EventKind::Access(
+            AccessKind::Close(AccessMode::Write)
+        )));
         // Content-changing events (a real `/admin/manifest` write/rename) still do.
-        assert!(!watcher_event_is_ignorable(&EventKind::Modify(ModifyKind::Any)));
-        assert!(!watcher_event_is_ignorable(&EventKind::Create(CreateKind::Any)));
-        assert!(!watcher_event_is_ignorable(&EventKind::Remove(RemoveKind::Any)));
+        assert!(!watcher_event_is_ignorable(&EventKind::Modify(
+            ModifyKind::Any
+        )));
+        assert!(!watcher_event_is_ignorable(&EventKind::Create(
+            CreateKind::Any
+        )));
+        assert!(!watcher_event_is_ignorable(&EventKind::Remove(
+            RemoveKind::Any
+        )));
     }
 
     fn overlay_route(env: &[(&str, &str)]) -> IntegrityRoute {

--- a/core-host/src/host_core/supervisors.rs
+++ b/core-host/src/host_core/supervisors.rs
@@ -28,6 +28,15 @@ pub(crate) fn spawn_reload_watcher(_state: AppState) {}
 
 pub(crate) const MANIFEST_FILE_WATCHER_DEBOUNCE: Duration = Duration::from_millis(250);
 
+/// Whether a filesystem event on the manifest directory should be ignored by the
+/// hot-reload watcher. Pure access/open events do not change the file's contents
+/// (a `/admin/manifest` update *writes* it), and on some filesystems every read —
+/// including the periodic S3 backup flush reading `integrity.lock` — emits one;
+/// reacting to those re-armed the watcher into an infinite reload loop.
+fn watcher_event_is_ignorable(kind: &notify::EventKind) -> bool {
+    matches!(kind, notify::EventKind::Access(_))
+}
+
 /// Spawn a file watcher that triggers a hot reload whenever the integrity manifest is
 /// modified or atomically replaced on disk. Many editors and CI/CD tools save the file
 /// by writing a temp file and renaming it over the original, so the watcher is set up
@@ -60,6 +69,18 @@ pub(crate) fn spawn_manifest_file_watcher(state: AppState) {
     let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
         match res {
             Ok(event) => {
+                // Ignore pure access/open events. On some filesystems (notably the
+                // WSL2/k3s `local-path` PVC backing `/data`) every *read* of the
+                // manifest emits an `Access(Open)` event — including the periodic
+                // S3 backup flush reading `integrity.lock` to upload it. Treating
+                // those as changes triggered a hot reload that re-read the file,
+                // which emitted another access event, sustaining an infinite
+                // reload loop. Only react to events that can alter the contents
+                // (Create/Modify/Remove/rename); a real `/admin/manifest` update
+                // writes the file, so legitimate hot reloads are unaffected.
+                if watcher_event_is_ignorable(&event.kind) {
+                    return;
+                }
                 let touches_manifest = event
                     .paths
                     .iter()
@@ -67,9 +88,6 @@ pub(crate) fn spawn_manifest_file_watcher(state: AppState) {
                 if !touches_manifest {
                     return;
                 }
-                // DEBUG: surface what is rewriting the manifest. A steady stream
-                // of these (with the same path) means something is touching
-                // integrity.lock in a loop and churning hot reloads.
                 tracing::info!(
                     event_kind = ?event.kind,
                     paths = ?event.paths,
@@ -917,6 +935,23 @@ fn cron_field_matches(field: &str, value: u32) -> bool {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn watcher_ignores_access_events_but_not_writes() {
+        use notify::event::{AccessKind, AccessMode, CreateKind, ModifyKind, RemoveKind};
+        use notify::EventKind;
+        // The exact event the WSL2/k3s `local-path` PVC emits on every read of the
+        // manifest (e.g. the S3 backup flush) — must NOT trigger a reload.
+        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Open(
+            AccessMode::Any
+        ))));
+        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Read)));
+        assert!(watcher_event_is_ignorable(&EventKind::Access(AccessKind::Any)));
+        // Content-changing events (a real `/admin/manifest` write/rename) still do.
+        assert!(!watcher_event_is_ignorable(&EventKind::Modify(ModifyKind::Any)));
+        assert!(!watcher_event_is_ignorable(&EventKind::Create(CreateKind::Any)));
+        assert!(!watcher_event_is_ignorable(&EventKind::Remove(RemoveKind::Any)));
+    }
 
     fn overlay_route(env: &[(&str, &str)]) -> IntegrityRoute {
         IntegrityRoute {


### PR DESCRIPTION
## Problème

Le watcher du manifeste déclenchait un hot-reload sur **tout** événement notify touchant `integrity.lock`, y compris `Access(Open)`. Sur le PVC `local-path` (WSL2/k3s) qui adosse `/data`, **chaque lecture** du fichier émet un tel événement — et le **flush S3 de fond lit `integrity.lock`** pour le sauvegarder — donc chaque lecture relançait un reload qui re-lisait le fichier → **boucle de hot-reload infinie** (drain continu des générations runtime).

Diagnostiqué via le log de debug du watcher :
```
manifest file watcher: change detected … event_kind=Access(Open(Any)) paths=["/data/integrity.lock"]
INFO supervisors: Hot reload successful manifest=/data/integrity.lock
… (en boucle)
```

## Correctif

Ignorer les événements `Access`/open dans le watcher ; seuls `Create`/`Modify`/`Remove`/rename (une vraie écriture via `/admin/manifest`) déclenchent un reload. Prédicat extrait `watcher_event_is_ignorable` + test de non-régression.

**Le backup/restore S3 n'est pas touché** — c'est volontaire (cf. #168, qui couvre le vrai fix de fond : validation des assets au seal/import, sans mutiler la restauration).

## Vérification

- `cargo test -p core-host watcher_ignores_access_events_but_not_writes` : ✅

Refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)