### PR TITLE
Corrige les versions des actions GitHub dans les workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -50,7 +50,7 @@ jobs:
         run: tar -czf wasm-guests.tar.gz target/wasm32-wasip1/release/*.wasm target/wasm32-wasip2/release/*.wasm
 
       - name: Upload guest artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
           path: wasm-guests.tar.gz
@@ -65,7 +65,7 @@ jobs:
             examples/guest-examples/manifest.json
 
       - name: Upload example guest modules archive
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: guest-examples-${{ github.sha }}
           path: guest-examples.tar.gz
@@ -114,13 +114,13 @@ jobs:
             target: fips-builder
             cache_scope: docker-fips
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Warm ${{ matrix.cache_scope }} cache (${{ matrix.dockerfile }} → ${{ matrix.target }})
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         continue-on-error: true
         with:
           context: .
@@ -136,7 +136,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -167,7 +167,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       RUSTFLAGS: "-D dead_code"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Install Linux system dependencies for Tauri
         run: |
@@ -241,7 +241,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       RUSTFLAGS: "-D dead_code"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -263,7 +263,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -289,7 +289,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       RUSTFLAGS: "-D dead_code"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -307,7 +307,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -317,7 +317,7 @@ jobs:
         run: cargo llvm-cov -p core-host --lcov --output-path lcov.info
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: core-host-lcov-${{ github.sha }}
           if-no-files-found: error
@@ -338,7 +338,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: "thin"
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -353,7 +353,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -363,7 +363,7 @@ jobs:
         run: cargo build -p core-host --release
 
       - name: Upload CI build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: tachyon-mesh-build-${{ github.sha }}
           if-no-files-found: error
@@ -419,7 +419,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-D dead_code"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -446,7 +446,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -480,7 +480,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: "thin"
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -498,7 +498,7 @@ jobs:
           sudo apt-get install -y cmake nasm protobuf-compiler
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -522,7 +522,7 @@ jobs:
           echo "label=${label}" >> "$GITHUB_OUTPUT"
 
       - name: Upload core-host binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: core-host-linux-x86_64-${{ steps.feat_label.outputs.label }}-${{ github.sha }}
           path: target/release/core-host
@@ -535,7 +535,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -552,7 +552,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -575,7 +575,7 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: "thin"
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -589,7 +589,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
       - name: Unpack guest artifacts
@@ -599,7 +599,7 @@ jobs:
         run: cargo build -p core-host --release --features fips
 
       - name: Upload FIPS core-host binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: core-host-linux-x86_64-fips-${{ github.sha }}
           path: target/release/core-host
@@ -663,10 +663,10 @@ jobs:
             feature_tag: "-all-features"
             cache_scope: docker-default
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Normalize image owner
         id: owner
@@ -674,7 +674,7 @@ jobs:
         run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -682,7 +682,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ steps.owner.outputs.value }}/${{ matrix.image_name }}
           tags: |
@@ -699,7 +699,7 @@ jobs:
       # the transient push failure (re-pushing from the warm buildkit/gha cache).
       - name: Build and publish Docker image
         id: build
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         continue-on-error: true
         with:
           context: ${{ matrix.context }}
@@ -714,7 +714,7 @@ jobs:
 
       - name: Build and publish Docker image (retry)
         if: steps.build.outcome == 'failure'
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -27,17 +27,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       # Shared GHA cache scope with publish-docker-images and the other E2E
       # workflows: the FaaS/system wasm + legacy-mock layers are
       # feature-independent (the cargo-feature ARG comes later in the
       # Dockerfile), so a cache hit here skips ~15 min of compilation.
       - name: Build local Docker image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           tags: tachyon-mesh:local

--- a/.github/workflows/e2e-mesh.yml
+++ b/.github/workflows/e2e-mesh.yml
@@ -38,17 +38,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       # Shared GHA cache scope with publish-docker-images and the other E2E
       # workflows: the FaaS/system wasm + legacy-mock layers are
       # feature-independent (the cargo-feature ARG comes later in the
       # Dockerfile), so a cache hit here skips ~15 min of compilation.
       - name: Build local Docker image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           tags: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/e2e-zero-touch.yml
+++ b/.github/workflows/e2e-zero-touch.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Generate OIDC fixture (JWKS + discovery + signed JWT)
         run: node scripts/e2e/make-oidc-fixture.js "$ISSUER" fixture
@@ -60,13 +60,13 @@ jobs:
         run: node scripts/e2e/seal-zero-touch.js "$ISSUER"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       # Dockerfile.e2e builds only core-host + Rust wasm (no tauri-ui / polyglot
       # guests) — far smaller and faster to build and to import into k3d.
       # GHA cache scope persists across runs of this workflow.
       - name: Build slim image (embeds the sealed zero-touch config + cert-manager)
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
 
@@ -95,7 +95,7 @@ jobs:
           CI: "true"
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report-${{ github.sha }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       # The two image builds plus the k3d/containerd image imports below are
       # disk-heavy and have intermittently exhausted the ~14 GB free on
@@ -34,14 +34,14 @@ jobs:
           echo "Disk after cleanup:"; df -h /
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v3
 
       # Shared GHA cache scope with publish-docker-images and the other E2E
       # workflows: the FaaS/system wasm + legacy-mock layers are
       # feature-independent (the cargo-feature ARG comes later in the
       # Dockerfile), so a cache hit here skips ~15 min of compilation.
       - name: Build tachyon-mesh image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           tags: tachyon-mesh:test
@@ -50,7 +50,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=docker-default
 
       - name: Build legacy-mock image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: legacy-runtime
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Run QUIC Interop
         run: docker compose -f tests/conformance/quic/docker-compose.yml config

--- a/.github/workflows/miri-cwasm-cache.yml
+++ b/.github/workflows/miri-cwasm-cache.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
       MIRIFLAGS: "-Zmiri-disable-isolation"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -37,7 +37,7 @@ jobs:
         run: tar -czf wasm-guests.tar.gz target/wasm32-wasip1/release/*.wasm target/wasm32-wasip2/release/*.wasm
 
       - name: Upload guest artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
           path: wasm-guests.tar.gz
@@ -74,7 +74,7 @@ jobs:
           - shard: 7/8
             id: 8
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -89,7 +89,7 @@ jobs:
           tool: cargo-mutants@${{ env.CARGO_MUTANTS_VERSION }}
 
       - name: Download guest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: wasm-guests-${{ github.sha }}
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload mutation output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: mutants-auth-shard-${{ matrix.id }}-${{ github.sha }}
           path: mutants-auth-shard-${{ matrix.id }}

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -15,7 +15,7 @@ jobs:
   publish-sdks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -80,7 +80,7 @@ jobs:
         run: cargo install wkg --locked
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -165,7 +165,7 @@ jobs:
 
       - name: Install cosign
         if: runner.os != 'Windows'
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@v3
 
       - name: Sign binary archive with cosign (keyless OIDC)
         id: sign
@@ -187,7 +187,7 @@ jobs:
           echo "sbom_file=${SBOM}" >> "$GITHUB_OUTPUT"
 
       - name: Upload archive and supply-chain artifacts to GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             ${{ steps.pkg.outputs.tarball }}
@@ -231,10 +231,10 @@ jobs:
       CARGO_HTTP_TIMEOUT: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
@@ -320,7 +320,7 @@ jobs:
 
       - name: Upload desktop bundles
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           if-no-files-found: error
@@ -328,7 +328,7 @@ jobs:
 
       - name: Upload SBOM
         if: matrix.platform == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: tachyon-mesh-sbom
           if-no-files-found: error

--- a/.github/workflows/wit-compat.yml
+++ b/.github/workflows/wit-compat.yml
@@ -11,7 +11,7 @@ jobs:
   check-compat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Motivation
- Les workflows utilisaient des références d'actions non supportées/futures qui pouvaient faire échouer la validation et l'exécution CI.
- Aligner les actions sur des majors stables évite les ruptures dues à changements de version non rétro-compatibles des actions GitHub et des actions Docker/GHCR.
- Harmoniser les versions entre CI, E2E, release et publication d'artefacts pour réduire la maintenance et les erreurs transverses.

### Description
- Remplacement des références d'actions GitHub majeures non supportées par des majors stables, par exemple `actions/checkout@v7` -> `actions/checkout@v4`, `actions/setup-node@v6` -> `actions/setup-node@v4`, `actions/upload-artifact@v7` -> `actions/upload-artifact@v4` et `actions/download-artifact@v8` -> `actions/download-artifact@v4` dans les workflows affectés.
- Alignement des actions Docker et image workflows vers des versions stables : `docker/setup-buildx-action@v4.1.0` -> `docker/setup-buildx-action@v3`, `docker/build-push-action@v7.2.0` -> `docker/build-push-action@v6`, `docker/login-action@v4` -> `docker/login-action@v3` et `docker/metadata-action@v6.1.0` -> `docker/metadata-action@v5`.
- Mise à jour des outils de publication/signature : `sigstore/cosign-installer@v4.1.2` -> `sigstore/cosign-installer@v3` et `softprops/action-gh-release@v3` -> `softprops/action-gh-release@v2`.
- Changements appliqués aux workflows CI/E2E/integration/release/mutation/miri/publish-sdks/wit-compat et autres fichiers sous `.github/workflows/` pour uniformiser les versions.

### Testing
- Exécution de `actionlint` sur l'arborescence des workflows (`actionlint` téléchargé localement) pour valider la syntaxe et la compatibilité, résultat : réussi.
- Recherche par `rg` pour détecter les anciennes références d'actions remplacées, résultat : aucune référence restante trouvée après remplacement.
- Validation rapide des fichiers YAML avec un parseur Python pour s'assurer qu'ils restent valides, résultat : réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34ebc9ee50832085b957a8806cc2e7)