### PR TITLE
chore(deps): update tauri monorepo to v2.11.3 (#188)

### DIFF
--- a/tachyon-ui/package-lock.json
+++ b/tachyon-ui/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
-      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.3.tgz",
+      "integrity": "sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -895,23 +895,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.11.2",
-        "@tauri-apps/cli-darwin-x64": "2.11.2",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
+        "@tauri-apps/cli-darwin-arm64": "2.11.3",
+        "@tauri-apps/cli-darwin-x64": "2.11.3",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.3",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.3",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.3",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.3",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.3",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.3",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.3",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.3",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.3"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
-      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.3.tgz",
+      "integrity": "sha512-BxpaM8bsCoXs3wd4WKYhas/G1gs7+r7B+e4WnyRk2GEoVOouJB1hoL6E6YLXZDXbYci6VFdrNnobQwd2uVL4ew==",
       "cpu": [
         "arm64"
       ],
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
-      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.3.tgz",
+      "integrity": "sha512-DbZYuPB1ZEzcAHYeyCvo3ltzM27+aXwPloCrtexPnmgPgulYJm3TOq6aC4S+wPhSXteddg8zImtNkvx/gQzmwg==",
       "cpu": [
         "x64"
       ],
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
-      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.3.tgz",
+      "integrity": "sha512-741NduqBmz1XkdU8yz3OI/kBZtqHbvxo9F9ytIeWYU69/Ba9dcZEbqOU++Dp0G/XU8vAI0TfTywEl+p+BbLvaA==",
       "cpu": [
         "arm"
       ],
@@ -960,9 +960,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
-      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.3.tgz",
+      "integrity": "sha512-RWAXT8pTqIczXcoic+LXlo6uEbAXGB0cgh6Pg7Y9xVnEbzryQ1JHtRGj9SxzrKSemBIDBH6Qc24kK2G69i8ofA==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +980,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
-      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.3.tgz",
+      "integrity": "sha512-qomqYS+yAkd0gXMRmhguWXc7RfVN+XKKXaEwbf5QmKURwydLFOTldd6F8/WoZDSsBMrV8dpNxz0YneGLmobiSA==",
       "cpu": [
         "arm64"
       ],
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
-      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.3.tgz",
+      "integrity": "sha512-jOCXbDqeDj5XcclsOBAaXjtTgwZCVg8zEZ+dbPUCoADOgljFgL0rOkYTc96vUYgOrYEfuHYihWMxIDGaD6GwJw==",
       "cpu": [
         "riscv64"
       ],
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
-      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.3.tgz",
+      "integrity": "sha512-+u3HO/F3gHwL48t9gWN/urqZvpaEJzBFmTaq5eSIhvy8TOvnhb+LgJr3Q3BG+5JxuBrCUjqtOEz6gMttdJFSBA==",
       "cpu": [
         "x64"
       ],
@@ -1040,9 +1040,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
-      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.3.tgz",
+      "integrity": "sha512-spr5Jpr6KF/vehkLwJ0YmdGv8QwpWU+uw7J8bgijO0sox6ZCYsSNMbcsQjTqPi4xl+p0woIYpWXgChgHYpAc8g==",
       "cpu": [
         "x64"
       ],
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
-      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.3.tgz",
+      "integrity": "sha512-abkoRQih5xBa3vz2spWaex0kP/MzVzVPQHom2f8jnCq46R/luOD6Uy85EMU9/bfzf6ZzdorWJsgO+OMX90Fx2w==",
       "cpu": [
         "arm64"
       ],
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
-      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.3.tgz",
+      "integrity": "sha512-Vy6AvzFm1G40hg3r+OYDB3jkuu7R4wnMzbQBKuun9v6Cgg8IierpLL7toMzrZKs/8NlG8Sg4x1iLFR52oknyHg==",
       "cpu": [
         "ia32"
       ],
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
-      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.3.tgz",
+      "integrity": "sha512-GlciF75GdbseajOyib2aCHwE3BXIqZ1liGKWLFRvCdN5wm8h8hFssEVKQ/6E+2jsMLg9v7LCTb983YFnn0QSww==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
* chore(deps): update tauri monorepo to v2.11.3

* refresh (#192)

* Fix package identifier mismatch in wit/ai/model-registry.wit

model-registry.wit declared package tachyon:ai@1.1.0 while every other file in wit/ai/ (inference.wit, kv-partition.wit, training.wit) declares tachyon:mesh@1.1.0, causing wasm-tools to fail to parse wit/ai/ as a single component whenever any sibling file changes (breaks check-compat on unrelated PRs touching wit/ai/inference.wit etc).

* Implement tensor/pipeline/expert-parallel inference execution (#187)

* Add OpenSpec proposals for distributed inference, GPU execution, constrained decoding, and NPU/TPU support

Drafts four change proposals (proposal/design/tasks/spec deltas) covering the gaps identified in the prior code audit: tensor/pipeline/expert parallelism in the inference runtime, real GPU execution for the ONNX and NVFP4 paths, activation of the already-specified-but-unimplemented constrained decoding feature, and real NPU/TPU backends for heterogeneous accelerator orchestration.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Implement tensor/pipeline/expert-parallel execution primitives (Tasks 1-2)

Adds the parallel-execution WIT interface and a candle-Device-generic engine (core-host/src/ai_inference/parallel.rs) covering Megatron-style column/row-parallel sharding, pipeline-stage composition with bounded micro-batch admission, MoE expert placement/routing, and topology validation with typed TopologyError rejection. Adds real (CPU-baseline, CUDA-ordinal-probing) cluster topology discovery.

Wiring validate-parallel-topology into apply-model-deployment (Task 3) is documented as blocked in tasks.md: no host-side call path consumes that guest export today, and config-ai.wit's hardware-strategy record lacks the fields the validator needs.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Wire structural validation into apply-model-deployment, fix config-api build

Extract pure parallel-plan validation (ParallelStrategy/ClusterTopology/ TopologyError/validate_parallel_topology) into a new shared parallel-topology crate so it can be used by both core-host (hardware-aware checks once topology is discovered) and system-faas-config-api (structural-only checks at apply-model-deployment time, before hardware is known). Adds validate_plan_shape for the latter.

Extends config-ai.wit's hardware-strategy with device-ids, stage-layer-ranges, expert-device-map and pipeline-depth, and adds the missing expert-parallelism gpu-distribution variant, so a deployment can describe a real parallel plan.

Fixes a pre-existing, unrelated defect that left system-faas-config-api unable to build as a wasm32-wasip2 component: 13 wit_bindgen::generate! calls (one per config domain) each embedded export requirements that only one export! call satisfied. The 12 still-scaffold domains now use the `stubs` keyword; ai_contract gets a real Guest impl (AiConfigComponent) that validates deployments via parallel_topology::validate_plan_shape.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Add tensor-parallel Llama engine (Task 4)

Implement a from-scratch, Megatron-style tensor-parallel Llama forward pass (column-parallel gate/up projections, row-parallel down projection, replicated attention/embeddings/LM-head) since candle_transformers' Llama internals are private and can't be patched directly. Verified numerically equivalent to the dense reference on a real tiny checkpoint, with and without KV-cache decode continuation.

Also fixes a latent rank-mismatch bug in ColumnParallelLinear/ RowParallelLinear::forward, which only worked for 2-D inputs.

No live caller wires a deployment's hardware_strategy into model loading yet (try_load still hard-rejects non-cpu devices) — documented as a caveat in tasks.md, consistent with Tasks 2 and 3.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Add pipeline-parallel Llama engine with real TCP transport (Task 5)

Implement pipeline-parallel execution: contiguous transformer-layer stages reusing Task 4's TensorParallelBlock (degenerated to dense per stage), composed by PipelineParallelLlama and verified numerically equivalent to the dense reference. Stage 0 owns the embedding, the last stage owns the final norm + LM head.

Corrects two inaccuracies in design.md: the layer-wise streaming primitive it named as the per-stage executor is a placeholder forward pass (own doc comment says so), and "grpc-http2" is the FaaS HTTP router, not a node-to-node mesh transport, so there was nothing existing to reuse for cross-stage activation hand-off. Added a real point-to-point TCP transport (TcpStageTransport) instead, satisfying the existing StageTransport trait with a genuine OS-socket round trip.

Also wires the existing PipelineDepthGate into a real GPipe-style microbatch scheduler (run_pipeline_microbatched), verified against the single-batch run_pipeline reference.

As with Task 4, no live caller yet threads a pipeline_parallelism deployment into model loading; documented in tasks.md.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Add expert-parallel (MoE) execution engine for Task 6

Adds detect_expert_count for tensor-name-based MoE checkpoint detection (Mixtral/Qwen-MoE convention) and ExpertParallelMlp, a gate-then-route MoE MLP that groups tokens by expert id and dispatches each group only to its assigned device, avoiding dense replication. Verified numerically equivalent to literal per-token sparse dispatch. No live MoE checkpoint loader exists yet in candle_llm_runtime.rs, so the dense path remains the only one exercised at runtime today; documented as the same class of gap as Tasks 4-5.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Add remaining topology/regression tests and reconcile docs (Tasks 7-8)

Adds the missing VRAM-per-shard-exceeded typed-error test in parallel-topology and an explicit single-device regression test proving TensorParallelLlama degenerates to the dense reference, closing Task 7's gaps (the shard-correctness and insufficient-count/interconnect cases were already covered by Tasks 4-6's own verification).

Updates README's roadmap and adds an operator-facing note to config-ai.wit stating that tensor/pipeline/expert-parallelism are now executable engines, while being explicit that no deployment yet wires hardware-strategy into model loading. Also corrects two inaccuracies in this change's own ai-inference spec delta (a placeholder layer-wise primitive and a nonexistent gRPC/HTTP2 mesh transport reference; a typo'd TopologyError variant name) discovered while reconciling docs with what was actually built.


Claude-Session: https://claude.ai/code/session_01PokUPWzqVS7menwc73Rmjd

* Apply cargo fmt to satisfy CI quality check

Whitespace-only reformatting (struct literals, use statements); no logic changes.

* Fix WIT variant case syntax in topology-error

Variant case payloads use case-name(type), not record-style case-name: type; this was a syntax error caught by check-compat.

* Address review feedback and fix quality CI failures on the parallel-execution change

- Reject tensor-parallel shards with remainder features: ColumnParallelLinear::shard, RowParallelLinear::shard, and split_for_row_parallel now error instead of silently dropping remainder features when the dimension isn't evenly divisible by the device count.
- Reject device ids absent from the discovered topology in validate_parallel_topology, not just an undersized cluster.
- Require a pipeline-parallel plan's first stage to start at layer 0 in validate_plan_shape, and require the last stage to reach the model's last layer in PipelineParallelLlama::load.
- Fix PipelineParallelLlama::load building one shared VarBuilder for every stage: each stage's weights (embedding, attention, norms, MLP, LM head) now materialise on that stage's own device via a per-stage VarBuilder.
- Add #[allow(clippy::unwrap_used)] to the new ai_inference test modules and replace two useless vec! literals with arrays, matching the workspace's clippy -D warnings -D clippy::unwrap_used lane.

---------



* chore(deps): update github artifact actions (#189)



* chore(deps): update sigstore/cosign-installer action to v4 (#190)



* chore(deps): update softprops/action-gh-release action to v3 (#191)



---------




---------