### PR TITLE
Validate asset availability at seal time; drop guest-openai from examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5154,9 +5154,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",

--- a/core-host/src/host_core/integrity_config.rs
+++ b/core-host/src/host_core/integrity_config.rs
@@ -754,6 +754,13 @@ pub(crate) async fn admin_manifest_update_handler(
             .into_response();
     }
 
+    // Reject sealing a manifest that points at asset blobs we don't actually
+    // hold: such a route resolves to `tachyon://sha256:` but 404s at request
+    // time, and the broken state survives restarts once persisted.
+    if let Err(error) = validate_route_asset_availability(&new_config, &state.manifest_path) {
+        return (StatusCode::BAD_REQUEST, format!("{error:#}")).into_response();
+    }
+
     // Atomic write: stage to a tempfile, fsync, rename. The notify-based
     // watcher (Wave 1) sees the rename and triggers `reload_runtime_from_disk`.
     let manifest_path = state.manifest_path.clone();
@@ -878,6 +885,41 @@ pub(crate) fn validate_integrity_config(mut config: IntegrityConfig) -> Result<I
     config.resources = normalize_resources(config.resources, &config.routes, &route_registry)?;
     config.layer4 = normalize_layer4_config(config.layer4, &route_registry)?;
     Ok(config)
+}
+
+/// Rejects a manifest whose route targets point at content-addressed asset
+/// blobs (`tachyon://sha256:…`) that are not present in the local asset
+/// registry. Called at **seal/import time** (the `/admin/manifest` and bundle
+/// apply handlers) so an unusable manifest can never be signed and persisted —
+/// and therefore can never be restored across restarts/redeploys.
+///
+/// This is deliberately *not* part of [`validate_integrity_config`], which also
+/// runs on the boot/restore path: a restored, operator-signed `integrity.lock`
+/// is the legitimate disaster-recovery payload and must load even if the asset
+/// blobs are still being rehydrated. The guarantee is enforced at the point the
+/// manifest is created, not at the point it is recovered.
+pub(crate) fn validate_route_asset_availability(
+    config: &IntegrityConfig,
+    manifest_path: &Path,
+) -> Result<()> {
+    for route in &config.routes {
+        for target in &route.targets {
+            if system_storage::is_asset_uri(&target.module) {
+                system_storage::resolve_asset_uri(manifest_path, &target.module).map_err(
+                    |error| {
+                        anyhow!(
+                            "Integrity Validation Failed: route `{}` target `{}` references an \
+                             asset blob that is not present in the registry; upload the module \
+                             before sealing it: {error:#}",
+                            route.path,
+                            target.module
+                        )
+                    },
+                )?;
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_enrollment_config(enrollment: &EnrollmentConfig) -> Result<()> {
@@ -2420,6 +2462,12 @@ pub(crate) async fn admin_manifest_bundle_handler(
                 .into_response();
         }
     };
+
+    // Reject sealing a bundle whose route targets reference asset blobs that
+    // are not present in the registry — see `validate_route_asset_availability`.
+    if let Err(error) = validate_route_asset_availability(&new_config, &state.manifest_path) {
+        return (StatusCode::BAD_REQUEST, format!("{error:#}")).into_response();
+    }
 
     let current_version = state.runtime.load().config.config_version;
     if new_config.config_version <= current_version {

--- a/core-host/src/host_core/tests/config_validation.rs
+++ b/core-host/src/host_core/tests/config_validation.rs
@@ -914,3 +914,68 @@ fn validate_integrity_config_rejects_writable_user_route_volumes() {
         .to_string()
         .contains("cannot request writable direct host mounts"));
 }
+
+fn asset_uri_route(path: &str, asset_uri: &str) -> IntegrityRoute {
+    let mut route = IntegrityRoute::user(path);
+    route.targets = vec![RouteTarget {
+        module: asset_uri.to_owned(),
+        weight: 100,
+        websocket: false,
+        match_header: None,
+        requires: Vec::new(),
+    }];
+    route
+}
+
+#[test]
+fn validate_route_asset_availability_rejects_missing_blob() {
+    let manifest_path = unique_test_dir("asset-availability-missing").join("integrity.lock");
+    fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+        .expect("manifest dir should be created");
+
+    let digest = "0".repeat(64);
+    let asset_uri = format!("tachyon://sha256:{digest}");
+    let mut config = IntegrityConfig::default_sealed();
+    config.routes = vec![asset_uri_route("/v1/models", &asset_uri)];
+
+    let error = validate_route_asset_availability(&config, &manifest_path)
+        .expect_err("a route pointing at a missing asset blob must be rejected at seal time");
+
+    let message = error.to_string();
+    assert!(message.contains("/v1/models"), "message: {message}");
+    assert!(
+        message.contains("not present in the registry"),
+        "message: {message}"
+    );
+}
+
+#[test]
+fn validate_route_asset_availability_accepts_present_blob() {
+    let root = unique_test_dir("asset-availability-present");
+    let manifest_path = root.join("integrity.lock");
+    let assets_dir = root.join("asset-registry").join("assets");
+    fs::create_dir_all(&assets_dir).expect("asset dir should be created");
+
+    let digest = "a".repeat(64);
+    fs::write(assets_dir.join(format!("{digest}.wasm")), b"\x00asm")
+        .expect("asset blob should be written");
+
+    let asset_uri = format!("tachyon://sha256:{digest}");
+    let mut config = IntegrityConfig::default_sealed();
+    config.routes = vec![asset_uri_route("/v1/models", &asset_uri)];
+
+    validate_route_asset_availability(&config, &manifest_path)
+        .expect("a route whose asset blob exists must pass seal-time validation");
+}
+
+#[test]
+fn validate_route_asset_availability_ignores_module_name_targets() {
+    let manifest_path = unique_test_dir("asset-availability-module").join("integrity.lock");
+    let mut config = IntegrityConfig::default_sealed();
+    config.routes = vec![asset_uri_route("/grpc/hello", "guest-grpc")];
+
+    // Plain module-name targets are resolved at link time, not from the asset
+    // registry, so the availability check must leave them untouched.
+    validate_route_asset_availability(&config, &manifest_path)
+        .expect("module-name targets must not trigger asset-registry checks");
+}

--- a/examples/guest-examples/manifest.json
+++ b/examples/guest-examples/manifest.json
@@ -95,39 +95,6 @@
       "max_concurrency": 100,
       "version": "0.0.0",
       "dependencies": {}
-    },
-    {
-      "path": "/v1/models",
-      "role": "user",
-      "name": "openai-models",
-      "targets": [{ "module": "guest-openai", "weight": 100 }],
-      "min_instances": 0,
-      "max_concurrency": 100,
-      "version": "1.0.0",
-      "scopes": { "kv": ["ai-models-registry"] },
-      "dependencies": {}
-    },
-    {
-      "path": "/v1/chat/completions",
-      "role": "user",
-      "name": "openai-chat",
-      "targets": [{ "module": "guest-openai", "weight": 100 }],
-      "min_instances": 0,
-      "max_concurrency": 100,
-      "version": "1.0.0",
-      "scopes": { "kv": ["ai-models-registry"] },
-      "dependencies": {}
-    },
-    {
-      "path": "/internal/guest-openai/register",
-      "role": "user",
-      "name": "openai-registry",
-      "targets": [{ "module": "guest-openai", "weight": 100 }],
-      "min_instances": 0,
-      "max_concurrency": 100,
-      "version": "1.0.0",
-      "scopes": { "kv": ["ai-models-registry"] },
-      "dependencies": {}
     }
   ]
 }


### PR DESCRIPTION
Closes #168

## Problem

A manifest could be sealed/persisted with routes whose content-addressed asset blobs (`tachyon://sha256:…`) were missing from the registry. The route then resolves to the asset URI but 404s (`… not found in the embedded registry`). Because the sealed manifest is persisted (PVC) and restored from S3 on startup, the broken state survived restarts and redeploys.

Observed with the `guest-examples` package: importing it sealed `/v1/models`, `/v1/chat/completions`, `/internal/guest-openai/register` to a guest-openai blob that wasn't shipped, clobbering the working embedded module-based route → `/v1/models` 404s, uploaded models invisible in the UI.

## Changes

1. **Seal-time asset validation.** New `validate_route_asset_availability` in `core-host/src/host_core/integrity_config.rs`, invoked from both the `/admin/manifest` handler and the bundle-apply handler. Any manifest whose route target references an asset blob absent from the local registry is rejected with **400** before signing/persistence.

   The check runs at **seal/import time only** — deliberately *not* in `validate_integrity_config` (which also runs on the boot/restore path). This keeps S3 disaster-recovery of `integrity.lock` intact, per the issue's non-goals: the guarantee is enforced when the manifest is created, not when it is recovered.

2. **Remove guest-openai from the importable examples.** Dropped the `/v1/models`, `/v1/chat/completions`, and `/internal/guest-openai/register` routes from `examples/guest-examples/manifest.json`. guest-openai is the embedded production OpenAI surface, not an example; importing examples must not touch `/v1/*`.

## Tests

Added three unit tests in `config_validation.rs`:
- rejects a route pointing at a missing asset blob
- accepts a route whose asset blob exists
- ignores plain module-name targets (link-time resolution, not the asset registry)

All three pass; `cargo build` and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USoRAdc8saTD8Xb382468k

---
_Generated by [Claude Code](https://claude.ai/code/session_01USoRAdc8saTD8Xb382468k)_