### PR TITLE
[codex] Add Qwen 3.5 MoE NVFP4 runtime

### DIFF
--- a/core-host/src/ai_inference.rs
+++ b/core-host/src/ai_inference.rs
@@ -1,5 +1,7 @@
 #[path = "ai_inference/accelerator_backend.rs"]
 mod accelerator_backend;
+#[path = "ai_inference/architecture_registry.rs"]
+mod architecture_registry;
 #[path = "ai_inference/candle_llm_runtime.rs"]
 mod candle_llm_runtime;
 #[path = "ai_inference/candle_onnx_backend.rs"]
@@ -12,6 +14,8 @@ mod modelopt_nvfp4;
 pub(crate) mod parallel;
 #[path = "ai_inference/pipeline_parallel_llama.rs"]
 pub(crate) mod pipeline_parallel_llama;
+#[path = "ai_inference/qwen35_moe_runtime.rs"]
+mod qwen35_moe_runtime;
 #[path = "ai_inference/samplers.rs"]
 mod samplers;
 #[path = "ai_inference/tensor_parallel_llama.rs"]
@@ -19,7 +23,7 @@ pub(crate) mod tensor_parallel_llama;
 #[path = "ai_inference/vram_manager.rs"]
 pub(crate) mod vram_manager;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use candle_core::{
     bail as candle_bail, CpuStorage, CustomOp2, DType, Device, Layout, Shape,
     Tensor as CandleTensor,
@@ -944,6 +948,7 @@ enum CandleBackendModelKind {
     /// Native FP4-kernel execution without eager dequantization remains a
     /// documented follow-up.
     ModelOptNvfp4(Box<candle_llm_runtime::CandleLlmRuntime>),
+    Qwen35Moe(Box<qwen35_moe_runtime::Qwen35MoeRuntime>),
 }
 
 impl CandleBackendModel {
@@ -981,9 +986,36 @@ impl CandleBackendModel {
                 &binding.alias,
                 &binding.path,
             )? {
-                Some(directory) => CandleBackendModelKind::ModelOptNvfp4(Box::new(
-                    candle_llm_runtime::CandleLlmRuntime::try_load_modelopt_nvfp4(&directory)?,
-                )),
+                Some(model) => {
+                    static DESCRIPTORS: [&dyn architecture_registry::ArchitectureDescriptor; 1] =
+                        [&qwen35_moe_runtime::QWEN35_MOE_DESCRIPTOR];
+                    let registry =
+                        architecture_registry::ArchitectureRegistry::new(&DESCRIPTORS);
+                    match registry.resolve(&model)? {
+                        Some(architecture)
+                            if architecture.kind
+                                == architecture_registry::ArchitectureKind::Qwen35MoeText =>
+                        {
+                            CandleBackendModelKind::Qwen35Moe(Box::new(
+                                qwen35_moe_runtime::Qwen35MoeRuntime::from_model(
+                                    &binding.alias,
+                                    &binding.path,
+                                    binding.device.as_str(),
+                                    model,
+                                )?,
+                            ))
+                        }
+                        Some(architecture) => {
+                            return Err(anyhow!(
+                                "unsupported registered ModelOpt/NVFP4 architecture {:?}",
+                                architecture.kind
+                            ));
+                        }
+                        None => CandleBackendModelKind::ModelOptNvfp4(Box::new(
+                            candle_llm_runtime::CandleLlmRuntime::try_load_modelopt_nvfp4(&model)?,
+                        )),
+                    }
+                }
                 None => match candle_llm_runtime::CandleLlmRuntime::try_load(
                     &binding.alias,
                     &binding.path,
@@ -1031,6 +1063,28 @@ impl BackendModel for CandleBackendModel {
 
     fn execute(&self, inputs: &[SharedInputTensor]) -> Result<Vec<u8>> {
         match &self.kind {
+            CandleBackendModelKind::Qwen35Moe(runtime) => {
+                if inputs
+                    .iter()
+                    .any(|input| !matches!(input.ty, TensorType::U8))
+                {
+                    return Err(anyhow!(
+                        "Qwen 3.5 MoE model `{}` only accepts U8 prompt tensors",
+                        self.source.alias
+                    ));
+                }
+                let prompts = inputs
+                    .iter()
+                    .map(|input| input.data.as_ref())
+                    .collect::<Vec<_>>();
+                return runtime.generate(&prompts).map_err(|error| {
+                    anyhow!(
+                        "Qwen 3.5 MoE model `{}` loaded from `{}` failed: {error}",
+                        self.source.alias,
+                        runtime.root().display()
+                    )
+                });
+            }
             CandleBackendModelKind::ModelOptNvfp4(runtime)
             | CandleBackendModelKind::TextGeneration(runtime) => {
                 if inputs
@@ -1083,40 +1137,61 @@ impl BackendModel for CandleBackendModel {
         inputs: &[SharedInputTensor],
         on_token: &mut dyn FnMut(&str),
     ) -> Result<()> {
-        // Only the text-generation backend decodes incrementally; everything
-        // else (mock, NVFP4) uses the trait's buffered emit-once fallback.
-        let CandleBackendModelKind::TextGeneration(runtime) = &self.kind else {
-            let output = self.execute(inputs)?;
-            let text = String::from_utf8(output)
-                .map_err(|error| anyhow!("output was not UTF-8: {error}"))?;
-            if !text.is_empty() {
-                on_token(&text);
+        match &self.kind {
+            CandleBackendModelKind::ModelOptNvfp4(runtime)
+            | CandleBackendModelKind::TextGeneration(runtime) => {
+                validate_u8_prompts(&self.source.alias, inputs)?;
+                let prompts = inputs
+                    .iter()
+                    .map(|input| input.data.as_ref())
+                    .collect::<Vec<_>>();
+                runtime
+                    .generate_streaming(&prompts, on_token)
+                    .map_err(|error| {
+                        anyhow!(
+                            "Candle LLM model `{}` loaded from `{}` failed: {error}",
+                            self.source.alias,
+                            runtime.root().display()
+                        )
+                    })
             }
-            return Ok(());
-        };
-        if inputs
-            .iter()
-            .any(|input| !matches!(input.ty, TensorType::U8))
-        {
-            return Err(anyhow!(
-                "Candle LLM model `{}` only accepts U8 prompt tensors",
-                self.source.alias
-            ));
+            CandleBackendModelKind::Qwen35Moe(runtime) => {
+                validate_u8_prompts(&self.source.alias, inputs)?;
+                let prompts = inputs
+                    .iter()
+                    .map(|input| input.data.as_ref())
+                    .collect::<Vec<_>>();
+                runtime
+                    .generate_streaming(&prompts, on_token)
+                    .map_err(|error| {
+                        anyhow!(
+                            "Qwen 3.5 MoE model `{}` loaded from `{}` failed: {error}",
+                            self.source.alias,
+                            runtime.root().display()
+                        )
+                    })
+            }
+            CandleBackendModelKind::Mock => {
+                let output = self.execute(inputs)?;
+                let text = String::from_utf8(output)
+                    .map_err(|error| anyhow!("output was not UTF-8: {error}"))?;
+                if !text.is_empty() {
+                    on_token(&text);
+                }
+                Ok(())
+            }
         }
-        let prompts = inputs
-            .iter()
-            .map(|input| input.data.as_ref())
-            .collect::<Vec<_>>();
-        runtime
-            .generate_streaming(&prompts, on_token)
-            .map_err(|error| {
-                anyhow!(
-                    "Candle LLM model `{}` loaded from `{}` failed: {error}",
-                    self.source.alias,
-                    runtime.root().display()
-                )
-            })
     }
+}
+
+fn validate_u8_prompts(alias: &str, inputs: &[SharedInputTensor]) -> Result<()> {
+    if inputs
+        .iter()
+        .any(|input| !matches!(input.ty, TensorType::U8))
+    {
+        bail!("text-generation model `{alias}` only accepts U8 prompt tensors");
+    }
+    Ok(())
 }
 
 struct CandleModel {

--- a/core-host/src/ai_inference/architecture_registry.rs
+++ b/core-host/src/ai_inference/architecture_registry.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+
+use super::modelopt_nvfp4::ModelOptNvfp4Directory;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ArchitectureKind {
+    Qwen35MoeText,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ArchitectureMatch {
+    pub(crate) kind: ArchitectureKind,
+    pub(crate) profile: &'static str,
+}
+
+pub(crate) trait ArchitectureDescriptor: Sync {
+    fn inspect(&self, model: &ModelOptNvfp4Directory) -> Result<Option<ArchitectureMatch>>;
+}
+
+pub(crate) struct ArchitectureRegistry {
+    descriptors: &'static [&'static dyn ArchitectureDescriptor],
+}
+
+impl ArchitectureRegistry {
+    pub(crate) const fn new(descriptors: &'static [&'static dyn ArchitectureDescriptor]) -> Self {
+        Self { descriptors }
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        model: &ModelOptNvfp4Directory,
+    ) -> Result<Option<ArchitectureMatch>> {
+        for descriptor in self.descriptors {
+            if let Some(matched) = descriptor.inspect(model)? {
+                return Ok(Some(matched));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/core-host/src/ai_inference/candle_llm_runtime.rs
+++ b/core-host/src/ai_inference/candle_llm_runtime.rs
@@ -298,9 +298,9 @@ struct SafetensorsIndex {
 /// Rendered into a prompt by the model's own chat template at parse time.
 /// `Serialize` so it can be handed to the Jinja chat-template context.
 #[derive(Debug, Clone, Deserialize, serde::Serialize)]
-struct ChatTurn {
-    role: String,
-    content: String,
+pub(crate) struct ChatTurn {
+    pub(crate) role: String,
+    pub(crate) content: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1618,7 +1618,7 @@ fn render_generic_chat(messages: &[ChatTurn]) -> String {
 /// A checkpoint's chat template, extracted once from `tokenizer_config.json`.
 /// Rendering uses minijinja with the Python-compatibility method set so real
 /// Hugging Face instruct templates (which call `.strip()`, `.split()`, …) work.
-struct ChatTemplate {
+pub(crate) struct ChatTemplate {
     source: String,
     bos_token: String,
     eos_token: String,
@@ -1686,7 +1686,7 @@ impl ChatTemplateField {
 impl ChatTemplate {
     /// Load the model's chat template from `tokenizer_config.json`, or `None`
     /// when the file or the `chat_template` field is absent.
-    fn load(alias: &str, root: &Path) -> Result<Option<Self>, CandleLlmError> {
+    pub(crate) fn load(alias: &str, root: &Path) -> Result<Option<Self>, CandleLlmError> {
         let path = root.join(TOKENIZER_CONFIG_JSON);
         if !path.exists() {
             return Ok(None);
@@ -1725,7 +1725,7 @@ impl ChatTemplate {
 
     /// Render `messages` through the Jinja template with `add_generation_prompt`
     /// set, so the prompt ends ready for the assistant to continue.
-    fn render(&self, messages: &[ChatTurn]) -> Result<String, String> {
+    pub(crate) fn render(&self, messages: &[ChatTurn]) -> Result<String, String> {
         let mut env = minijinja::Environment::new();
         // Real HF templates call `raise_exception(...)` to reject malformed
         // conversations (e.g. a system turn where the model forbids one).

--- a/core-host/src/ai_inference/modelopt_nvfp4.rs
+++ b/core-host/src/ai_inference/modelopt_nvfp4.rs
@@ -5,9 +5,10 @@ use std::{
     fs::File,
     io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde_json::Value;
 
 #[cfg(feature = "nvfp4-cuda")]
@@ -130,7 +131,10 @@ pub(crate) enum Nvfp4ExecutionPlan {
 pub(crate) struct ModelOptNvfp4Directory {
     alias: String,
     root: PathBuf,
+    config_json: Option<Value>,
+    hf_quant_json: Option<Value>,
     shard_index: SafetensorsShardIndex,
+    header_cache: Arc<Mutex<BTreeMap<PathBuf, SafetensorsHeader>>>,
     quantization: ModelOptNvfp4QuantizationLayout,
 }
 
@@ -192,7 +196,10 @@ impl ModelOptNvfp4Directory {
         Ok(Some(Self {
             alias: alias.to_owned(),
             root: root.to_path_buf(),
+            config_json,
+            hf_quant_json,
             shard_index,
+            header_cache: Arc::new(Mutex::new(BTreeMap::new())),
             quantization,
         }))
     }
@@ -209,9 +216,20 @@ impl ModelOptNvfp4Directory {
         &self.quantization
     }
 
+    pub(crate) fn config_json(&self) -> Option<&Value> {
+        self.config_json.as_ref()
+    }
+
+    pub(crate) fn hf_quant_json(&self) -> Option<&Value> {
+        self.hf_quant_json.as_ref()
+    }
+
+    pub(crate) fn contains_tensor(&self, tensor_name: &str) -> bool {
+        self.shard_index.contains_tensor(tensor_name)
+    }
+
     /// Every tensor name the checkpoint declares, across all shards. Callers
-    /// building a dense in-memory model (the NVFP4 fallback execution path)
-    /// walk this to classify and materialize each parameter in turn.
+    /// building a runtime walk this to classify and materialize parameters.
     pub(crate) fn tensor_names(&self) -> impl Iterator<Item = &str> {
         self.shard_index.tensor_names()
     }
@@ -227,13 +245,23 @@ impl ModelOptNvfp4Directory {
                 tensor: tensor_name.to_owned(),
             }
         })?;
-        let header = SafetensorsHeader::read(&location.shard_path)?;
-        let info = header.tensor(tensor_name).ok_or_else(|| {
-            ModelOptNvfp4LoadError::TensorNotFoundInShard {
-                alias: self.alias.clone(),
-                tensor: tensor_name.to_owned(),
-                shard: location.shard_path.clone(),
+        let info = {
+            let mut cache = self
+                .header_cache
+                .lock()
+                .map_err(|_| anyhow::anyhow!("safetensors header cache lock is poisoned"))?;
+            if !cache.contains_key(&location.shard_path) {
+                let header = SafetensorsHeader::read(&location.shard_path)?;
+                cache.insert(location.shard_path.clone(), header);
             }
+            cache
+                .get(&location.shard_path)
+                .and_then(|header| header.tensor(tensor_name))
+        };
+        let info = info.ok_or_else(|| ModelOptNvfp4LoadError::TensorNotFoundInShard {
+            alias: self.alias.clone(),
+            tensor: tensor_name.to_owned(),
+            shard: location.shard_path.clone(),
         })?;
         Ok(SafetensorsTensorRef {
             name: tensor_name.to_owned(),
@@ -547,6 +575,10 @@ impl SafetensorsShardIndex {
             .any(|tensor| tensor.ends_with(suffix))
     }
 
+    pub(crate) fn contains_tensor(&self, tensor_name: &str) -> bool {
+        self.weight_map.contains_key(tensor_name)
+    }
+
     pub(crate) fn tensor_names(&self) -> impl Iterator<Item = &str> {
         self.weight_map.keys().map(String::as_str)
     }
@@ -605,6 +637,141 @@ pub(crate) struct SafetensorsTensorRef {
     pub(crate) name: String,
     pub(crate) shard_path: PathBuf,
     pub(crate) info: SafetensorsTensorInfo,
+}
+
+impl SafetensorsTensorRef {
+    pub(crate) fn read_bytes(&self) -> Result<Vec<u8>> {
+        let mut file = File::open(&self.shard_path).with_context(|| {
+            format!(
+                "failed to open safetensors shard `{}`",
+                self.shard_path.display()
+            )
+        })?;
+        let mut prefix = [0u8; 8];
+        file.read_exact(&mut prefix)?;
+        let header_len = u64::from_le_bytes(prefix);
+        let data_start = 8u64
+            .checked_add(header_len)
+            .context("safetensors data offset overflow")?;
+        let start = data_start
+            .checked_add(u64::try_from(self.info.data_offsets.0)?)
+            .context("safetensors tensor start offset overflow")?;
+        let len = self
+            .info
+            .data_offsets
+            .1
+            .checked_sub(self.info.data_offsets.0)
+            .context("invalid safetensors tensor offsets")?;
+        file.seek(SeekFrom::Start(start))?;
+        let mut bytes = vec![0u8; len];
+        file.read_exact(&mut bytes).with_context(|| {
+            format!(
+                "failed to read tensor `{}` from `{}`",
+                self.name,
+                self.shard_path.display()
+            )
+        })?;
+        Ok(bytes)
+    }
+
+    pub(crate) fn read_f32(&self) -> Result<Vec<f32>> {
+        let bytes = self.read_bytes()?;
+        let expected = elem_count(&self.info.shape);
+        let values: Vec<f32> = match self.info.dtype {
+            SafetensorsDType::F8E4M3 => bytes.into_iter().map(e4m3_to_f32).collect(),
+            SafetensorsDType::BF16 => bytes
+                .chunks_exact(2)
+                .map(|chunk| {
+                    let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                    f32::from_bits(u32::from(bits) << 16)
+                })
+                .collect(),
+            SafetensorsDType::F16 => bytes
+                .chunks_exact(2)
+                .map(|chunk| f16_bits_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
+                .collect(),
+            SafetensorsDType::F32 => bytes
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect(),
+            dtype => bail!(
+                "tensor `{}` cannot be decoded as f32 from dtype {dtype:?}",
+                self.name
+            ),
+        };
+        if values.len() != expected {
+            bail!(
+                "tensor `{}` decoded {} values, expected {expected}",
+                self.name,
+                values.len()
+            );
+        }
+        Ok(values)
+    }
+
+    pub(crate) fn read_f32_slice(
+        &self,
+        element_start: usize,
+        element_len: usize,
+    ) -> Result<Vec<f32>> {
+        let element_size = match self.info.dtype {
+            SafetensorsDType::F8E4M3 => 1usize,
+            SafetensorsDType::BF16 | SafetensorsDType::F16 => 2,
+            SafetensorsDType::F32 => 4,
+            dtype => bail!(
+                "tensor `{}` cannot be sliced as f32 from dtype {dtype:?}",
+                self.name
+            ),
+        };
+        let total = elem_count(&self.info.shape);
+        let element_end = element_start
+            .checked_add(element_len)
+            .context("tensor slice range overflow")?;
+        if element_end > total {
+            bail!(
+                "tensor `{}` slice [{element_start}..{element_end}] exceeds {total} elements",
+                self.name
+            );
+        }
+        let byte_start = element_start
+            .checked_mul(element_size)
+            .context("tensor slice byte offset overflow")?;
+        let byte_len = element_len
+            .checked_mul(element_size)
+            .context("tensor slice byte length overflow")?;
+        let mut file = File::open(&self.shard_path)?;
+        let mut prefix = [0u8; 8];
+        file.read_exact(&mut prefix)?;
+        let data_start = 8u64
+            .checked_add(u64::from_le_bytes(prefix))
+            .context("safetensors data offset overflow")?;
+        let tensor_start = data_start
+            .checked_add(u64::try_from(self.info.data_offsets.0)?)
+            .and_then(|offset| offset.checked_add(u64::try_from(byte_start).ok()?))
+            .context("tensor slice start offset overflow")?;
+        file.seek(SeekFrom::Start(tensor_start))?;
+        let mut bytes = vec![0u8; byte_len];
+        file.read_exact(&mut bytes)?;
+        let values = match self.info.dtype {
+            SafetensorsDType::F8E4M3 => bytes.into_iter().map(e4m3_to_f32).collect(),
+            SafetensorsDType::BF16 => bytes
+                .chunks_exact(2)
+                .map(|chunk| {
+                    f32::from_bits(u32::from(u16::from_le_bytes([chunk[0], chunk[1]])) << 16)
+                })
+                .collect(),
+            SafetensorsDType::F16 => bytes
+                .chunks_exact(2)
+                .map(|chunk| f16_bits_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
+                .collect(),
+            SafetensorsDType::F32 => bytes
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect(),
+            _ => unreachable!(),
+        };
+        Ok(values)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -764,56 +931,6 @@ impl SafetensorsHeader {
     }
 }
 
-impl SafetensorsTensorRef {
-    /// Reads this tensor's raw little-endian bytes straight from its shard
-    /// file. Used by the dense (fallback) NVFP4 execution path to materialize
-    /// an in-memory model: the packed FP4 weight, its FP8 block scales, and
-    /// the F32 tensor scale are each read this way before dequantization, and
-    /// passthrough (unquantized) tensors are read this way to feed
-    /// `Tensor::from_raw_buffer` directly.
-    pub(crate) fn read_bytes(&self) -> Result<Vec<u8>> {
-        let mut file = File::open(&self.shard_path).with_context(|| {
-            format!(
-                "failed to open safetensors shard `{}`",
-                self.shard_path.display()
-            )
-        })?;
-        let mut prefix = [0u8; 8];
-        file.read_exact(&mut prefix).with_context(|| {
-            format!(
-                "failed to read safetensors header prefix from `{}`",
-                self.shard_path.display()
-            )
-        })?;
-        let header_len = u64::from_le_bytes(prefix) as usize;
-        let (start, end) = self.info.data_offsets;
-        let data_start = 8usize
-            .checked_add(header_len)
-            .and_then(|base| base.checked_add(start))
-            .ok_or_else(|| ModelOptNvfp4LoadError::UnsupportedQuantization {
-                alias: self.name.clone(),
-                detail: "tensor data offset overflows usize".to_owned(),
-            })?;
-        file.seek(SeekFrom::Start(data_start as u64))
-            .with_context(|| {
-                format!(
-                    "failed to seek to tensor `{}` data in `{}`",
-                    self.name,
-                    self.shard_path.display()
-                )
-            })?;
-        let mut buf = vec![0u8; end.saturating_sub(start)];
-        file.read_exact(&mut buf).with_context(|| {
-            format!(
-                "failed to read tensor `{}` data from `{}`",
-                self.name,
-                self.shard_path.display()
-            )
-        })?;
-        Ok(buf)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PackedFp4TensorRef {
     pub(crate) tensor: SafetensorsTensorRef,
@@ -874,6 +991,208 @@ pub(crate) enum ModelOptLinearTensors {
     Nvfp4(Nvfp4LinearTensors),
     Fp8(Fp8LinearTensors),
     Passthrough(PassthroughTensorRef),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum PreparedLinear {
+    Dense {
+        rows: usize,
+        cols: usize,
+        weight: Vec<f32>,
+    },
+    Fp8 {
+        rows: usize,
+        cols: usize,
+        weight: Vec<u8>,
+        scale: f32,
+    },
+    Nvfp4 {
+        rows: usize,
+        cols: usize,
+        packed: Vec<u8>,
+        scales: Vec<u8>,
+        tensor_scale: f32,
+    },
+}
+
+impl PreparedLinear {
+    pub(crate) fn resident_bytes(&self) -> u64 {
+        match self {
+            Self::Dense { weight, .. } => (weight.len() as u64).saturating_mul(4),
+            Self::Fp8 { weight, .. } => weight.len() as u64,
+            Self::Nvfp4 { packed, scales, .. } => {
+                (packed.len() as u64).saturating_add(scales.len() as u64)
+            }
+        }
+    }
+
+    pub(crate) fn matvec(&self, input: &[f32]) -> Result<Vec<f32>> {
+        let (rows, cols) = match self {
+            Self::Dense { rows, cols, .. }
+            | Self::Fp8 { rows, cols, .. }
+            | Self::Nvfp4 { rows, cols, .. } => (*rows, *cols),
+        };
+        if input.len() != cols {
+            bail!("linear input has {} values, expected {cols}", input.len());
+        }
+        let mut output = vec![0.0f32; rows];
+        match self {
+            Self::Dense { weight, .. } => {
+                for (row, output_value) in output.iter_mut().enumerate() {
+                    *output_value = weight[row * cols..(row + 1) * cols]
+                        .iter()
+                        .zip(input)
+                        .map(|(weight, input)| weight * input)
+                        .sum();
+                }
+            }
+            Self::Fp8 { weight, scale, .. } => {
+                for (row, output_value) in output.iter_mut().enumerate() {
+                    *output_value = weight[row * cols..(row + 1) * cols]
+                        .iter()
+                        .zip(input)
+                        .map(|(weight, input)| e4m3_to_f32(*weight) * scale * input)
+                        .sum();
+                }
+            }
+            Self::Nvfp4 {
+                packed,
+                scales,
+                tensor_scale,
+                ..
+            } => {
+                let packed_cols = cols / 2;
+                let scale_cols = cols / NVFP4_BLOCK_SIZE;
+                for row in 0..rows {
+                    let mut sum = 0.0;
+                    for block in 0..scale_cols {
+                        let scale = e4m3_to_f32(scales[row * scale_cols + block]) * tensor_scale;
+                        let packed_offset = row * packed_cols + block * (NVFP4_BLOCK_SIZE / 2);
+                        let input_offset = block * NVFP4_BLOCK_SIZE;
+                        for byte_index in 0..NVFP4_BLOCK_SIZE / 2 {
+                            let byte = packed[packed_offset + byte_index];
+                            let value_index = input_offset + byte_index * 2;
+                            sum += E2M1_LUT[(byte >> 4) as usize] * scale * input[value_index];
+                            sum +=
+                                E2M1_LUT[(byte & 0x0f) as usize] * scale * input[value_index + 1];
+                        }
+                    }
+                    output[row] = sum;
+                }
+            }
+        }
+        Ok(output)
+    }
+}
+
+impl ModelOptLinearTensors {
+    pub(crate) fn logical_shape(&self) -> Result<(usize, usize)> {
+        let shape = match self {
+            Self::Nvfp4(linear) => {
+                let shape = &linear.packed_weight.tensor.info.shape;
+                vec![shape[0], shape[1] * 2]
+            }
+            Self::Fp8(linear) => linear.weight.info.shape.clone(),
+            Self::Passthrough(linear) => linear.tensor.info.shape.clone(),
+        };
+        if shape.len() != 2 {
+            bail!("linear weight must be rank 2, got {shape:?}");
+        }
+        Ok((shape[0], shape[1]))
+    }
+
+    pub(crate) fn dequantize_f32(&self, max_dense_bytes: Option<u64>) -> Result<Vec<f32>> {
+        let (rows, cols) = self.logical_shape()?;
+        let bytes = u64::try_from(rows)?
+            .saturating_mul(u64::try_from(cols)?)
+            .saturating_mul(4);
+        if max_dense_bytes.is_some_and(|limit| bytes > limit) {
+            bail!(
+                "linear fallback needs {bytes} dense bytes for [{rows}, {cols}], exceeding limit {}",
+                max_dense_bytes.unwrap_or_default()
+            );
+        }
+        match self {
+            Self::Passthrough(linear) => linear.tensor.read_f32(),
+            Self::Fp8(linear) => {
+                let scale = read_scalar_f32(&linear.weight_scale.tensor)?;
+                Ok(linear
+                    .weight
+                    .read_f32()?
+                    .into_iter()
+                    .map(|value| value * scale)
+                    .collect())
+            }
+            Self::Nvfp4(linear) => {
+                let packed = linear.packed_weight.tensor.read_bytes()?;
+                let block_scales = linear.block_scales.tensor.read_bytes()?;
+                let tensor_scale = read_scalar_f32(&linear.tensor_scale.tensor)?;
+                let Nvfp4DenseValues::F32(values) = dequantize_nvfp4_e4m3(
+                    &packed,
+                    &block_scales,
+                    tensor_scale,
+                    rows,
+                    cols,
+                    Nvfp4OutputDType::F32,
+                )?
+                else {
+                    unreachable!("F32 output was requested")
+                };
+                Ok(values)
+            }
+        }
+    }
+
+    pub(crate) fn matvec_f32(
+        &self,
+        input: &[f32],
+        max_dense_bytes: Option<u64>,
+    ) -> Result<Vec<f32>> {
+        let (_, cols) = self.logical_shape()?;
+        if input.len() != cols {
+            bail!("linear input has {} values, expected {cols}", input.len());
+        }
+        self.prepare(max_dense_bytes)?.matvec(input)
+    }
+
+    pub(crate) fn prepare(&self, max_dense_bytes: Option<u64>) -> Result<PreparedLinear> {
+        let (rows, cols) = self.logical_shape()?;
+        match self {
+            Self::Nvfp4(linear) => {
+                let packed = linear.packed_weight.tensor.read_bytes()?;
+                let scales = linear.block_scales.tensor.read_bytes()?;
+                let tensor_scale = read_scalar_f32(&linear.tensor_scale.tensor)?;
+                Ok(PreparedLinear::Nvfp4 {
+                    rows,
+                    cols,
+                    packed,
+                    scales,
+                    tensor_scale,
+                })
+            }
+            Self::Fp8(linear) => {
+                let weight = linear.weight.read_bytes()?;
+                let scale = read_scalar_f32(&linear.weight_scale.tensor)?;
+                Ok(PreparedLinear::Fp8 {
+                    rows,
+                    cols,
+                    weight,
+                    scale,
+                })
+            }
+            Self::Passthrough(linear) => {
+                let weight = linear.tensor.read_f32()?;
+                let dense_bytes = (weight.len() as u64).saturating_mul(4);
+                if max_dense_bytes.is_some_and(|limit| dense_bytes > limit) {
+                    bail!(
+                        "linear fallback needs {dense_bytes} dense bytes, exceeding limit {}",
+                        max_dense_bytes.unwrap_or_default()
+                    );
+                }
+                Ok(PreparedLinear::Dense { rows, cols, weight })
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1265,6 +1584,39 @@ fn f32_to_bf16_bits(value: f32) -> u16 {
     let lsb = (bits >> 16) & 1;
     let rounded = bits.wrapping_add(0x7fff + lsb);
     (rounded >> 16) as u16
+}
+
+fn f16_bits_to_f32(bits: u16) -> f32 {
+    let sign = u32::from(bits & 0x8000) << 16;
+    let exponent = (bits >> 10) & 0x1f;
+    let fraction = bits & 0x03ff;
+    let value = match exponent {
+        0 if fraction == 0 => sign,
+        0 => {
+            let mut fraction = u32::from(fraction);
+            let mut exponent = 113u32;
+            while fraction & 0x0400 == 0 {
+                fraction <<= 1;
+                exponent -= 1;
+            }
+            sign | (exponent << 23) | ((fraction & 0x03ff) << 13)
+        }
+        0x1f => sign | 0x7f80_0000 | (u32::from(fraction) << 13),
+        _ => sign | (u32::from(exponent + 112) << 23) | (u32::from(fraction) << 13),
+    };
+    f32::from_bits(value)
+}
+
+fn read_scalar_f32(tensor: &SafetensorsTensorRef) -> Result<f32> {
+    let values = tensor.read_f32()?;
+    if values.len() != 1 {
+        bail!(
+            "tensor `{}` must contain one scalar, got {} values",
+            tensor.name,
+            values.len()
+        );
+    }
+    Ok(values[0])
 }
 
 #[cfg(test)]
@@ -1692,6 +2044,68 @@ mod tests {
             .expect_err("invalid K should fail");
 
         assert!(error.to_string().contains("multiple of block size"));
+    }
+
+    #[test]
+    fn quantized_linear_fallback_matvec_is_bounded() {
+        let root = temp_model_dir("modelopt-linear-matvec");
+        write_minimal_modelopt_nvfp4_dir(&root);
+        let model = ModelOptNvfp4Directory::try_load("nvfp4", &root)
+            .expect("loader should not error")
+            .expect("directory should be detected");
+        let linear = model
+            .modelopt_linear(TEST_LINEAR)
+            .expect("linear should load");
+
+        let output = linear
+            .matvec_f32(&[1.0; 16], Some(1024))
+            .expect("bounded fallback should run");
+        assert_eq!(output, vec![0.0]);
+
+        let bounded = linear
+            .matvec_f32(&[1.0; 16], Some(1))
+            .expect("packed matvec must not allocate a dense weight window");
+        assert_eq!(bounded, vec![0.0]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn f16_conversion_handles_normal_subnormal_and_infinity() {
+        assert_eq!(f16_bits_to_f32(0x3c00), 1.0);
+        assert!(f16_bits_to_f32(0x0001) > 0.0);
+        assert!(f16_bits_to_f32(0x7c00).is_infinite());
+    }
+
+    #[test]
+    fn mixed_dense_fp8_nvfp4_graph_matches_expected_output() {
+        let mut dense_weight = vec![0.0; 16 * 16];
+        let mut fp8_weight = vec![0u8; 16 * 16];
+        for index in 0..16 {
+            dense_weight[index * 16 + index] = 1.0;
+            fp8_weight[index * 16 + index] = 0x38;
+        }
+        let dense = PreparedLinear::Dense {
+            rows: 16,
+            cols: 16,
+            weight: dense_weight,
+        };
+        let fp8 = PreparedLinear::Fp8 {
+            rows: 16,
+            cols: 16,
+            weight: fp8_weight,
+            scale: 1.0,
+        };
+        let nvfp4 = PreparedLinear::Nvfp4 {
+            rows: 1,
+            cols: 16,
+            packed: vec![0x22; 8],
+            scales: vec![0x38],
+            tensor_scale: 1.0,
+        };
+        let dense_output = dense.matvec(&[1.0; 16]).expect("dense");
+        let fp8_output = fp8.matvec(&dense_output).expect("fp8");
+        let output = nvfp4.matvec(&fp8_output).expect("nvfp4");
+        assert_eq!(output, vec![16.0]);
     }
 
     #[test]

--- a/core-host/src/ai_inference/qwen35_moe_primitives.rs
+++ b/core-host/src/ai_inference/qwen35_moe_primitives.rs
@@ -1,0 +1,513 @@
+use anyhow::{bail, Result};
+
+use super::LayerType;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct FullAttentionState {
+    pub(crate) keys: Vec<Vec<f32>>,
+    pub(crate) values: Vec<Vec<f32>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct LinearAttentionState {
+    pub(crate) conv: Vec<Vec<f32>>,
+    pub(crate) recurrent: Vec<Vec<f32>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum LayerDecodeState {
+    Full(FullAttentionState),
+    Linear(LinearAttentionState),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct HybridDecodeState {
+    pub(crate) layers: Vec<LayerDecodeState>,
+}
+
+impl HybridDecodeState {
+    pub(crate) fn new(layer_types: &[LayerType]) -> Self {
+        Self {
+            layers: layer_types
+                .iter()
+                .map(|layer| match layer {
+                    LayerType::FullAttention => {
+                        LayerDecodeState::Full(FullAttentionState::default())
+                    }
+                    LayerType::LinearAttention => {
+                        LayerDecodeState::Linear(LinearAttentionState::default())
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn resident_bytes(&self) -> u64 {
+        self.layers
+            .iter()
+            .map(|layer| match layer {
+                LayerDecodeState::Full(state) => state
+                    .keys
+                    .iter()
+                    .chain(&state.values)
+                    .map(|values| (values.len() as u64).saturating_mul(4))
+                    .sum::<u64>(),
+                LayerDecodeState::Linear(state) => state
+                    .conv
+                    .iter()
+                    .chain(&state.recurrent)
+                    .map(|values| (values.len() as u64).saturating_mul(4))
+                    .sum::<u64>(),
+            })
+            .sum::<u64>()
+    }
+}
+
+pub(crate) fn rms_norm_qwen(input: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>> {
+    if input.len() != weight.len() || input.is_empty() {
+        bail!("RMSNorm input and weight dimensions must match and be non-empty");
+    }
+    let mean_square = input.iter().map(|value| value * value).sum::<f32>() / input.len() as f32;
+    let inv = 1.0 / (mean_square + eps).sqrt();
+    Ok(input
+        .iter()
+        .zip(weight)
+        .map(|(value, weight)| value * inv * (1.0 + weight))
+        .collect())
+}
+
+pub(crate) fn silu(value: f32) -> f32 {
+    value / (1.0 + (-value).exp())
+}
+
+pub(crate) fn sigmoid(value: f32) -> f32 {
+    1.0 / (1.0 + (-value).exp())
+}
+
+pub(crate) fn route_top_k(logits: &[f32], top_k: usize) -> Result<Vec<(usize, f32)>> {
+    if top_k == 0 || top_k > logits.len() {
+        bail!("top-k must be in 1..={}", logits.len());
+    }
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut probabilities = logits
+        .iter()
+        .enumerate()
+        .map(|(index, value)| (index, (*value - max).exp()))
+        .collect::<Vec<_>>();
+    let total = probabilities.iter().map(|(_, value)| value).sum::<f32>();
+    for (_, value) in &mut probabilities {
+        *value /= total;
+    }
+    probabilities.sort_by(|(left_index, left), (right_index, right)| {
+        right
+            .total_cmp(left)
+            .then_with(|| left_index.cmp(right_index))
+    });
+    probabilities.truncate(top_k);
+    let selected_total = probabilities.iter().map(|(_, value)| value).sum::<f32>();
+    for (_, value) in &mut probabilities {
+        *value /= selected_total;
+    }
+    Ok(probabilities)
+}
+
+pub(crate) fn sparse_moe_forward(
+    hidden: &[f32],
+    router_logits: &[f32],
+    top_k: usize,
+    mut expert: impl FnMut(usize, &[f32]) -> Result<Vec<f32>>,
+    shared_expert: impl FnOnce(&[f32]) -> Result<Vec<f32>>,
+    shared_gate_logit: f32,
+) -> Result<Vec<f32>> {
+    let routes = route_top_k(router_logits, top_k)?;
+    let mut output = vec![0.0f32; hidden.len()];
+    for (expert_index, weight) in routes {
+        let values = expert(expert_index, hidden)?;
+        if values.len() != hidden.len() {
+            bail!("expert {expert_index} returned an invalid hidden dimension");
+        }
+        for (output, value) in output.iter_mut().zip(values) {
+            *output += value * weight;
+        }
+    }
+    let shared = shared_expert(hidden)?;
+    if shared.len() != hidden.len() {
+        bail!("shared expert returned an invalid hidden dimension");
+    }
+    let gate = sigmoid(shared_gate_logit);
+    for (output, value) in output.iter_mut().zip(shared) {
+        *output += value * gate;
+    }
+    Ok(output)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn full_attention_step(
+    query_and_gate: &[f32],
+    key: &[f32],
+    value: &[f32],
+    q_norm_weight: &[f32],
+    k_norm_weight: &[f32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    rope_theta: f32,
+    position: usize,
+    state: &mut FullAttentionState,
+) -> Result<Vec<f32>> {
+    let query_width = num_heads * head_dim;
+    let kv_width = num_kv_heads * head_dim;
+    if query_and_gate.len() != query_width * 2
+        || key.len() != kv_width
+        || value.len() != kv_width
+        || q_norm_weight.len() != head_dim
+        || k_norm_weight.len() != head_dim
+        || !num_heads.is_multiple_of(num_kv_heads)
+        || rotary_dim > head_dim
+        || !rotary_dim.is_multiple_of(2)
+    {
+        bail!("invalid full-attention dimensions");
+    }
+    let (query, gate) = query_and_gate.split_at(query_width);
+    let mut normalized_q = Vec::with_capacity(query_width);
+    for head in query.chunks_exact(head_dim) {
+        normalized_q.extend(rms_norm_qwen(head, q_norm_weight, 1e-6)?);
+    }
+    let mut normalized_k = Vec::with_capacity(kv_width);
+    for head in key.chunks_exact(head_dim) {
+        normalized_k.extend(rms_norm_qwen(head, k_norm_weight, 1e-6)?);
+    }
+    apply_partial_rotary(
+        &mut normalized_q,
+        num_heads,
+        head_dim,
+        rotary_dim,
+        rope_theta,
+        position,
+    );
+    apply_partial_rotary(
+        &mut normalized_k,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        rope_theta,
+        position,
+    );
+    state.keys.push(normalized_k);
+    state.values.push(value.to_vec());
+
+    let groups = num_heads / num_kv_heads;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let mut output = vec![0.0f32; query_width];
+    for head in 0..num_heads {
+        let kv_head = head / groups;
+        let q = &normalized_q[head * head_dim..(head + 1) * head_dim];
+        let mut scores = state
+            .keys
+            .iter()
+            .map(|token| {
+                let k = &token[kv_head * head_dim..(kv_head + 1) * head_dim];
+                q.iter().zip(k).map(|(q, k)| q * k).sum::<f32>() * scale
+            })
+            .collect::<Vec<_>>();
+        softmax_in_place(&mut scores);
+        for (token_index, score) in scores.into_iter().enumerate() {
+            let v = &state.values[token_index][kv_head * head_dim..(kv_head + 1) * head_dim];
+            for dim in 0..head_dim {
+                output[head * head_dim + dim] += score * v[dim];
+            }
+        }
+    }
+    for (output, gate) in output.iter_mut().zip(gate) {
+        *output *= sigmoid(*gate);
+    }
+    Ok(output)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gated_delta_step(
+    projected_qkv: &[f32],
+    z: &[f32],
+    b: &[f32],
+    a: &[f32],
+    conv_weights: &[f32],
+    a_log: &[f32],
+    dt_bias: &[f32],
+    norm_weight: &[f32],
+    num_key_heads: usize,
+    num_value_heads: usize,
+    key_head_dim: usize,
+    value_head_dim: usize,
+    conv_kernel: usize,
+    state: &mut LinearAttentionState,
+) -> Result<Vec<f32>> {
+    let key_dim = num_key_heads * key_head_dim;
+    let value_dim = num_value_heads * value_head_dim;
+    let conv_dim = key_dim * 2 + value_dim;
+    if projected_qkv.len() != conv_dim
+        || z.len() != value_dim
+        || b.len() != num_value_heads
+        || a.len() != num_value_heads
+        || conv_weights.len() != conv_dim * conv_kernel
+        || a_log.len() != num_value_heads
+        || dt_bias.len() != num_value_heads
+        || norm_weight.len() != value_head_dim
+        || !num_value_heads.is_multiple_of(num_key_heads)
+        || conv_kernel == 0
+    {
+        bail!("invalid gated-delta dimensions");
+    }
+    if state.conv.is_empty() {
+        state.conv = vec![vec![0.0; conv_kernel.saturating_sub(1)]; conv_dim];
+    }
+    let mut mixed = vec![0.0f32; conv_dim];
+    for channel in 0..conv_dim {
+        let history = &mut state.conv[channel];
+        let mut window = history.clone();
+        window.push(projected_qkv[channel]);
+        mixed[channel] = silu(
+            window
+                .iter()
+                .zip(&conv_weights[channel * conv_kernel..(channel + 1) * conv_kernel])
+                .map(|(input, weight)| input * weight)
+                .sum(),
+        );
+        if conv_kernel > 1 {
+            history.copy_from_slice(&window[1..]);
+        }
+    }
+    let (query, tail) = mixed.split_at(key_dim);
+    let (key, value) = tail.split_at(key_dim);
+    if state.recurrent.is_empty() {
+        state.recurrent = vec![vec![0.0; key_head_dim * value_head_dim]; num_value_heads];
+    }
+    let repeat = num_value_heads / num_key_heads;
+    let mut output = vec![0.0f32; value_dim];
+    for value_head in 0..num_value_heads {
+        let key_head = value_head / repeat;
+        let q = l2_normalize(&query[key_head * key_head_dim..(key_head + 1) * key_head_dim]);
+        let k = l2_normalize(&key[key_head * key_head_dim..(key_head + 1) * key_head_dim]);
+        let v = &value[value_head * value_head_dim..(value_head + 1) * value_head_dim];
+        let beta = sigmoid(b[value_head]);
+        let decay =
+            (-a_log[value_head].exp() * softplus(a[value_head] + dt_bias[value_head])).exp();
+        let recurrent = &mut state.recurrent[value_head];
+        for element in recurrent.iter_mut() {
+            *element *= decay;
+        }
+        let mut memory = vec![0.0f32; value_head_dim];
+        for key_dim_index in 0..key_head_dim {
+            for value_dim_index in 0..value_head_dim {
+                memory[value_dim_index] +=
+                    recurrent[key_dim_index * value_head_dim + value_dim_index] * k[key_dim_index];
+            }
+        }
+        let delta = v
+            .iter()
+            .zip(memory)
+            .map(|(value, memory)| (value - memory) * beta)
+            .collect::<Vec<_>>();
+        for key_dim_index in 0..key_head_dim {
+            for value_dim_index in 0..value_head_dim {
+                recurrent[key_dim_index * value_head_dim + value_dim_index] +=
+                    k[key_dim_index] * delta[value_dim_index];
+            }
+        }
+        let head_output =
+            &mut output[value_head * value_head_dim..(value_head + 1) * value_head_dim];
+        for key_dim_index in 0..key_head_dim {
+            for value_dim_index in 0..value_head_dim {
+                head_output[value_dim_index] +=
+                    recurrent[key_dim_index * value_head_dim + value_dim_index] * q[key_dim_index]
+                        / (key_head_dim as f32).sqrt();
+            }
+        }
+        let normalized = rms_norm_plain(head_output, norm_weight, 1e-6)?;
+        for (index, normalized) in normalized.into_iter().enumerate() {
+            head_output[index] = normalized * silu(z[value_head * value_head_dim + index]);
+        }
+    }
+    Ok(output)
+}
+
+fn rms_norm_plain(input: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>> {
+    if input.len() != weight.len() || input.is_empty() {
+        bail!("gated RMSNorm dimensions must match");
+    }
+    let mean_square = input.iter().map(|value| value * value).sum::<f32>() / input.len() as f32;
+    let inv = 1.0 / (mean_square + eps).sqrt();
+    Ok(input
+        .iter()
+        .zip(weight)
+        .map(|(value, weight)| value * inv * weight)
+        .collect())
+}
+
+fn apply_partial_rotary(
+    values: &mut [f32],
+    heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    theta: f32,
+    position: usize,
+) {
+    for head in 0..heads {
+        let offset = head * head_dim;
+        for pair in 0..rotary_dim / 2 {
+            let frequency = theta.powf(-((2 * pair) as f32) / rotary_dim as f32);
+            let angle = position as f32 * frequency;
+            let left = values[offset + pair];
+            let right = values[offset + rotary_dim / 2 + pair];
+            values[offset + pair] = left * angle.cos() - right * angle.sin();
+            values[offset + rotary_dim / 2 + pair] = right * angle.cos() + left * angle.sin();
+        }
+    }
+}
+
+fn softmax_in_place(values: &mut [f32]) {
+    let max = values.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut total = 0.0;
+    for value in values.iter_mut() {
+        *value = (*value - max).exp();
+        total += *value;
+    }
+    for value in values {
+        *value /= total;
+    }
+}
+
+fn l2_normalize(values: &[f32]) -> Vec<f32> {
+    let inv = 1.0 / (values.iter().map(|value| value * value).sum::<f32>() + 1e-6).sqrt();
+    values.iter().map(|value| value * inv).collect()
+}
+
+fn softplus(value: f32) -> f32 {
+    if value > 20.0 {
+        value
+    } else {
+        (1.0 + value.exp()).ln()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn router_ties_are_deterministic_and_renormalized() {
+        let routes = route_top_k(&[1.0, 1.0, 0.0], 2).expect("route");
+        assert_eq!(routes[0].0, 0);
+        assert_eq!(routes[1].0, 1);
+        assert!((routes.iter().map(|(_, weight)| weight).sum::<f32>() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sparse_moe_executes_only_selected_experts_and_shared_expert() {
+        let mut visited = Vec::new();
+        let output = sparse_moe_forward(
+            &[1.0, 2.0],
+            &[4.0, 3.0, -2.0],
+            2,
+            |index, hidden| {
+                visited.push(index);
+                Ok(hidden
+                    .iter()
+                    .map(|value| value * (index + 1) as f32)
+                    .collect())
+            },
+            |hidden| Ok(hidden.to_vec()),
+            0.0,
+        )
+        .expect("MoE");
+        assert_eq!(visited, vec![0, 1]);
+        assert_eq!(output.len(), 2);
+    }
+
+    #[test]
+    fn sparse_moe_rejects_invalid_expert_components() {
+        let error = sparse_moe_forward(
+            &[1.0, 2.0],
+            &[1.0, 0.0],
+            1,
+            |_index, _hidden| Ok(vec![1.0]),
+            |hidden| Ok(hidden.to_vec()),
+            0.0,
+        )
+        .expect_err("invalid expert output must fail");
+        assert!(error.to_string().contains("invalid hidden dimension"));
+    }
+
+    #[test]
+    fn hybrid_state_separates_full_and_linear_attention() {
+        let state = HybridDecodeState::new(&[LayerType::LinearAttention, LayerType::FullAttention]);
+        assert!(matches!(state.layers[0], LayerDecodeState::Linear(_)));
+        assert!(matches!(state.layers[1], LayerDecodeState::Full(_)));
+        assert_eq!(state.resident_bytes(), 0);
+    }
+
+    #[test]
+    fn full_attention_reuses_cached_keys_and_values() {
+        let mut state = FullAttentionState::default();
+        let first = full_attention_step(
+            &[1.0, 0.0, 8.0, 8.0],
+            &[1.0, 0.0],
+            &[2.0, 3.0],
+            &[0.0, 0.0],
+            &[0.0, 0.0],
+            1,
+            1,
+            2,
+            2,
+            10_000.0,
+            0,
+            &mut state,
+        )
+        .expect("first");
+        let second = full_attention_step(
+            &[0.0, 1.0, 8.0, 8.0],
+            &[0.0, 1.0],
+            &[4.0, 5.0],
+            &[0.0, 0.0],
+            &[0.0, 0.0],
+            1,
+            1,
+            2,
+            2,
+            10_000.0,
+            1,
+            &mut state,
+        )
+        .expect("second");
+        assert_eq!(state.keys.len(), 2);
+        assert_ne!(first, second);
+        assert!(first[0] > 1.99 && first[0] < 2.0);
+        assert!(first[1] > 2.99 && first[1] < 3.0);
+    }
+
+    #[test]
+    fn gated_delta_updates_convolution_and_recurrent_state() {
+        let mut state = LinearAttentionState::default();
+        let output = gated_delta_step(
+            &[1.0, 1.0, 2.0],
+            &[1.0],
+            &[0.0],
+            &[0.0],
+            &[1.0, 1.0, 1.0],
+            &[0.0],
+            &[0.0],
+            &[1.0],
+            1,
+            1,
+            1,
+            1,
+            1,
+            &mut state,
+        )
+        .expect("delta");
+        assert_eq!(output.len(), 1);
+        assert_eq!(state.recurrent.len(), 1);
+        assert_ne!(state.recurrent[0][0], 0.0);
+        assert!((output[0] - 0.731_058_6).abs() < 1e-4);
+    }
+}

--- a/core-host/src/ai_inference/qwen35_moe_runtime.rs
+++ b/core-host/src/ai_inference/qwen35_moe_runtime.rs
@@ -1,0 +1,1188 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use candle_core::{Device, Tensor};
+use candle_transformers::generation::{LogitsProcessor, Sampling};
+use serde::Deserialize;
+use serde_json::Value;
+use tokenizers::Tokenizer;
+
+use super::{
+    architecture_registry::{ArchitectureDescriptor, ArchitectureKind, ArchitectureMatch},
+    candle_llm_runtime::{ChatTemplate, ChatTurn, HOST_MAX_NEW_TOKENS},
+    modelopt_nvfp4::{
+        ModelOptLinearTensors, ModelOptNvfp4Directory, PreparedLinear, SafetensorsDType,
+        NVFP4_BLOCK_SIZE,
+    },
+};
+use primitives::{
+    full_attention_step, gated_delta_step, rms_norm_qwen, sparse_moe_forward, HybridDecodeState,
+    LayerDecodeState,
+};
+
+#[path = "qwen35_moe_primitives.rs"]
+mod primitives;
+
+pub(crate) const QWEN35_MOE_PROFILE_V1: &str = "qwen3.5-moe-text-modelopt-0.44-v1";
+const OUTER_MODEL_TYPE: &str = "qwen3_5_moe";
+const TEXT_MODEL_TYPE: &str = "qwen3_5_moe_text";
+const ARCHITECTURE: &str = "Qwen3_5MoeForConditionalGeneration";
+const ACCEPTED_PRODUCER: &str = "modelopt";
+const ACCEPTED_PRODUCER_VERSION: &str = "0.44.0";
+
+pub(crate) static QWEN35_MOE_DESCRIPTOR: Qwen35MoeDescriptor = Qwen35MoeDescriptor;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Qwen35MoeDescriptor;
+
+impl ArchitectureDescriptor for Qwen35MoeDescriptor {
+    fn inspect(&self, model: &ModelOptNvfp4Directory) -> Result<Option<ArchitectureMatch>> {
+        let config = model
+            .config_json()
+            .context("ModelOpt Qwen 3.5 profile requires config.json")?;
+        if !declares_qwen35(config) {
+            return Ok(None);
+        }
+        Qwen35MoeConfig::validate_model(model)?;
+        Ok(Some(ArchitectureMatch {
+            kind: ArchitectureKind::Qwen35MoeText,
+            profile: QWEN35_MOE_PROFILE_V1,
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LayerType {
+    LinearAttention,
+    FullAttention,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct Qwen35MoeConfig {
+    pub(crate) model_type: String,
+    pub(crate) hidden_size: usize,
+    pub(crate) vocab_size: usize,
+    pub(crate) num_hidden_layers: usize,
+    pub(crate) layer_types: Vec<LayerType>,
+    pub(crate) num_attention_heads: usize,
+    pub(crate) num_key_value_heads: usize,
+    pub(crate) head_dim: usize,
+    pub(crate) partial_rotary_factor: f64,
+    pub(crate) rope_parameters: RopeParameters,
+    pub(crate) rms_norm_eps: f64,
+    pub(crate) linear_conv_kernel_dim: usize,
+    pub(crate) linear_key_head_dim: usize,
+    pub(crate) linear_value_head_dim: usize,
+    pub(crate) linear_num_key_heads: usize,
+    pub(crate) linear_num_value_heads: usize,
+    pub(crate) num_experts: usize,
+    pub(crate) num_experts_per_tok: usize,
+    pub(crate) moe_intermediate_size: usize,
+    pub(crate) shared_expert_intermediate_size: usize,
+    #[serde(default)]
+    pub(crate) mtp_num_hidden_layers: usize,
+    pub(crate) eos_token_id: u32,
+    pub(crate) max_position_embeddings: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct RopeParameters {
+    pub(crate) rope_theta: f64,
+}
+
+impl Qwen35MoeConfig {
+    pub(crate) fn from_model(model: &ModelOptNvfp4Directory) -> Result<Self> {
+        let root = model
+            .config_json()
+            .context("Qwen 3.5 MoE model is missing config.json")?;
+        let text = root
+            .get("text_config")
+            .context("Qwen 3.5 MoE config is missing text_config")?;
+        serde_json::from_value(text.clone()).context("invalid Qwen 3.5 MoE text_config")
+    }
+
+    pub(crate) fn validate_model(model: &ModelOptNvfp4Directory) -> Result<Self> {
+        validate_producer(model)?;
+        validate_quantization_metadata(model)?;
+        let config = Self::from_model(model)?;
+        config.validate_semantics()?;
+        config.validate_tensor_contract(model)?;
+        Ok(config)
+    }
+
+    fn validate_semantics(&self) -> Result<()> {
+        if self.model_type != TEXT_MODEL_TYPE {
+            bail!(
+                "Qwen 3.5 compatibility profile expects text model_type `{TEXT_MODEL_TYPE}`, got `{}`",
+                self.model_type
+            );
+        }
+        if self.num_hidden_layers == 0 || self.layer_types.len() != self.num_hidden_layers {
+            bail!(
+                "Qwen 3.5 layer_types length {} does not match num_hidden_layers {}",
+                self.layer_types.len(),
+                self.num_hidden_layers
+            );
+        }
+        if !self.layer_types.contains(&LayerType::LinearAttention)
+            || !self.layer_types.contains(&LayerType::FullAttention)
+        {
+            bail!(
+                "Qwen 3.5 hybrid profile requires both linear_attention and full_attention layers"
+            );
+        }
+        if self.hidden_size == 0
+            || self.vocab_size == 0
+            || self.num_attention_heads == 0
+            || self.num_key_value_heads == 0
+            || self.head_dim == 0
+        {
+            bail!("Qwen 3.5 attention and embedding dimensions must be non-zero");
+        }
+        if !self
+            .num_attention_heads
+            .is_multiple_of(self.num_key_value_heads)
+        {
+            bail!("num_attention_heads must be divisible by num_key_value_heads");
+        }
+        if !(0.0..=1.0).contains(&self.partial_rotary_factor) || self.partial_rotary_factor == 0.0 {
+            bail!("partial_rotary_factor must be in (0, 1]");
+        }
+        if self.linear_num_value_heads == 0
+            || self.linear_num_key_heads == 0
+            || !self
+                .linear_num_value_heads
+                .is_multiple_of(self.linear_num_key_heads)
+            || self.linear_key_head_dim == 0
+            || self.linear_value_head_dim == 0
+            || self.linear_conv_kernel_dim == 0
+        {
+            bail!("invalid Qwen 3.5 gated-delta linear-attention dimensions");
+        }
+        if self.num_experts == 0
+            || self.num_experts_per_tok == 0
+            || self.num_experts_per_tok > self.num_experts
+            || self.moe_intermediate_size == 0
+            || self.shared_expert_intermediate_size == 0
+        {
+            bail!("invalid Qwen 3.5 sparse-MoE dimensions");
+        }
+        if self.rms_norm_eps <= 0.0 {
+            bail!("rms_norm_eps must be positive");
+        }
+        let _ = self.mtp_num_hidden_layers;
+        Ok(())
+    }
+
+    fn validate_tensor_contract(&self, model: &ModelOptNvfp4Directory) -> Result<()> {
+        require_tensor_shape(
+            model,
+            "model.language_model.embed_tokens.weight",
+            &[self.vocab_size, self.hidden_size],
+        )?;
+        require_tensor_shape(
+            model,
+            "model.language_model.norm.weight",
+            &[self.hidden_size],
+        )?;
+        validate_linear_kind(
+            model,
+            "lm_head",
+            QuantKind::Nvfp4,
+            self.vocab_size,
+            self.hidden_size,
+        )?;
+
+        for (layer, layer_type) in self.layer_types.iter().enumerate() {
+            let prefix = format!("model.language_model.layers.{layer}");
+            require_tensor_shape(
+                model,
+                &format!("{prefix}.input_layernorm.weight"),
+                &[self.hidden_size],
+            )?;
+            require_tensor_shape(
+                model,
+                &format!("{prefix}.post_attention_layernorm.weight"),
+                &[self.hidden_size],
+            )?;
+            match layer_type {
+                LayerType::LinearAttention => {
+                    let key_dim = self.linear_num_key_heads * self.linear_key_head_dim;
+                    let value_dim = self.linear_num_value_heads * self.linear_value_head_dim;
+                    require_tensor_shape(
+                        model,
+                        &format!("{prefix}.linear_attn.A_log"),
+                        &[self.linear_num_value_heads],
+                    )?;
+                    require_tensor_shape(
+                        model,
+                        &format!("{prefix}.linear_attn.dt_bias"),
+                        &[self.linear_num_value_heads],
+                    )?;
+                    require_tensor_shape(
+                        model,
+                        &format!("{prefix}.linear_attn.conv1d.weight"),
+                        &[key_dim * 2 + value_dim, 1, self.linear_conv_kernel_dim],
+                    )?;
+                    for suffix in ["linear_attn.in_proj_a", "linear_attn.in_proj_b"] {
+                        validate_linear_kind(
+                            model,
+                            &format!("{prefix}.{suffix}"),
+                            QuantKind::Dense,
+                            self.linear_num_value_heads,
+                            self.hidden_size,
+                        )?;
+                    }
+                    require_tensor_shape(
+                        model,
+                        &format!("{prefix}.linear_attn.norm.weight"),
+                        &[self.linear_value_head_dim],
+                    )?;
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.linear_attn.in_proj_qkv"),
+                        QuantKind::Fp8,
+                        key_dim * 2 + value_dim,
+                        self.hidden_size,
+                    )?;
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.linear_attn.in_proj_z"),
+                        QuantKind::Fp8,
+                        value_dim,
+                        self.hidden_size,
+                    )?;
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.linear_attn.out_proj"),
+                        QuantKind::Fp8,
+                        self.hidden_size,
+                        value_dim,
+                    )?;
+                }
+                LayerType::FullAttention => {
+                    for suffix in ["self_attn.q_norm.weight", "self_attn.k_norm.weight"] {
+                        require_tensor_shape(
+                            model,
+                            &format!("{prefix}.{suffix}"),
+                            &[self.head_dim],
+                        )?;
+                    }
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.self_attn.q_proj"),
+                        QuantKind::Fp8,
+                        self.num_attention_heads * self.head_dim * 2,
+                        self.hidden_size,
+                    )?;
+                    for suffix in ["self_attn.k_proj", "self_attn.v_proj"] {
+                        validate_linear_kind(
+                            model,
+                            &format!("{prefix}.{suffix}"),
+                            QuantKind::Fp8,
+                            self.num_key_value_heads * self.head_dim,
+                            self.hidden_size,
+                        )?;
+                    }
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.self_attn.o_proj"),
+                        QuantKind::Fp8,
+                        self.hidden_size,
+                        self.num_attention_heads * self.head_dim,
+                    )?;
+                }
+            }
+
+            validate_linear_kind(
+                model,
+                &format!("{prefix}.mlp.gate"),
+                QuantKind::Dense,
+                self.num_experts,
+                self.hidden_size,
+            )?;
+            validate_linear_kind(
+                model,
+                &format!("{prefix}.mlp.shared_expert_gate"),
+                QuantKind::Dense,
+                1,
+                self.hidden_size,
+            )?;
+            for suffix in ["gate_proj", "up_proj"] {
+                validate_linear_kind(
+                    model,
+                    &format!("{prefix}.mlp.shared_expert.{suffix}"),
+                    QuantKind::Nvfp4,
+                    self.shared_expert_intermediate_size,
+                    self.hidden_size,
+                )?;
+            }
+            validate_linear_kind(
+                model,
+                &format!("{prefix}.mlp.shared_expert.down_proj"),
+                QuantKind::Nvfp4,
+                self.hidden_size,
+                self.shared_expert_intermediate_size,
+            )?;
+            for expert in 0..self.num_experts {
+                for projection in ["gate_proj", "up_proj"] {
+                    validate_linear_kind(
+                        model,
+                        &format!("{prefix}.mlp.experts.{expert}.{projection}"),
+                        QuantKind::Nvfp4,
+                        self.moe_intermediate_size,
+                        self.hidden_size,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "invalid expert tensor contract at layer {layer}, expert {expert}, component {projection}"
+                        )
+                    })?;
+                }
+                validate_linear_kind(
+                    model,
+                    &format!("{prefix}.mlp.experts.{expert}.down_proj"),
+                    QuantKind::Nvfp4,
+                    self.hidden_size,
+                    self.moe_intermediate_size,
+                )
+                .with_context(|| {
+                    format!(
+                        "invalid expert tensor contract at layer {layer}, expert {expert}, component down_proj"
+                    )
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct Qwen35MoeRuntime {
+    alias: String,
+    root: PathBuf,
+    model: ModelOptNvfp4Directory,
+    config: Qwen35MoeConfig,
+    tokenizer: Tokenizer,
+    chat_template: Option<ChatTemplate>,
+    max_dense_operator_bytes: u64,
+    working_set: Mutex<LinearWorkingSet>,
+}
+
+#[derive(Debug, Default)]
+struct WorkingSetStats {
+    hits: u64,
+    misses: u64,
+    evictions: u64,
+    transfers: u64,
+}
+
+#[derive(Debug)]
+struct LinearWorkingSet {
+    max_bytes: u64,
+    resident_bytes: u64,
+    values: BTreeMap<String, Arc<PreparedLinear>>,
+    order: VecDeque<String>,
+    stats: WorkingSetStats,
+}
+
+impl LinearWorkingSet {
+    fn new(max_bytes: u64) -> Self {
+        Self {
+            max_bytes,
+            resident_bytes: 0,
+            values: BTreeMap::new(),
+            order: VecDeque::new(),
+            stats: WorkingSetStats::default(),
+        }
+    }
+
+    fn get(&mut self, key: &str) -> Option<Arc<PreparedLinear>> {
+        let value = self.values.get(key).cloned();
+        if value.is_some() {
+            self.stats.hits += 1;
+            self.order.retain(|entry| entry != key);
+            self.order.push_back(key.to_owned());
+        } else {
+            self.stats.misses += 1;
+        }
+        value
+    }
+
+    fn insert(&mut self, key: String, value: Arc<PreparedLinear>) {
+        let bytes = value.resident_bytes();
+        self.stats.transfers += 1;
+        if bytes > self.max_bytes {
+            return;
+        }
+        while self.resident_bytes.saturating_add(bytes) > self.max_bytes {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if let Some(evicted) = self.values.remove(&oldest) {
+                self.resident_bytes = self.resident_bytes.saturating_sub(evicted.resident_bytes());
+                self.stats.evictions += 1;
+            }
+        }
+        self.resident_bytes = self.resident_bytes.saturating_add(bytes);
+        self.order.push_back(key.clone());
+        self.values.insert(key, value);
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GenerationRequest {
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    messages: Option<Vec<IncomingChatTurn>>,
+    #[serde(default = "default_max_new_tokens")]
+    max_new_tokens: usize,
+    #[serde(default)]
+    temperature: Option<f32>,
+    #[serde(default)]
+    top_p: Option<f32>,
+    #[serde(default)]
+    seed: Option<u64>,
+    #[serde(default)]
+    stop: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IncomingChatTurn {
+    role: String,
+    content: Value,
+}
+
+fn default_max_new_tokens() -> usize {
+    64
+}
+
+impl Qwen35MoeRuntime {
+    pub(crate) fn try_load(
+        alias: &str,
+        path: impl AsRef<Path>,
+        requested_device: &str,
+    ) -> Result<Option<Self>> {
+        let Some(model) = ModelOptNvfp4Directory::try_load(alias, path.as_ref())? else {
+            return Ok(None);
+        };
+        Self::from_model(alias, path, requested_device, model).map(Some)
+    }
+
+    pub(crate) fn from_model(
+        alias: &str,
+        path: impl AsRef<Path>,
+        requested_device: &str,
+        model: ModelOptNvfp4Directory,
+    ) -> Result<Self> {
+        let matched = QWEN35_MOE_DESCRIPTOR.inspect(&model)?.ok_or_else(|| {
+            anyhow!("ModelOpt/NVFP4 model `{alias}` does not match the Qwen 3.5 MoE text profile")
+        })?;
+        if matched.kind != ArchitectureKind::Qwen35MoeText {
+            bail!("resolved architecture is not Qwen 3.5 MoE text");
+        }
+        if requested_device != "cpu" && requested_device != "gpu" {
+            bail!(
+                "Qwen 3.5 MoE runtime supports `cpu` or capability-gated `gpu`, got `{requested_device}`"
+            );
+        }
+        let root = path.as_ref();
+        let tokenizer = Tokenizer::from_file(root.join("tokenizer.json"))
+            .map_err(|error| anyhow!("failed to load Qwen tokenizer.json: {error}"))?;
+        let chat_template = ChatTemplate::load(alias, root)?;
+        let config = Qwen35MoeConfig::validate_model(&model)?;
+        let max_dense_operator_bytes = std::env::var("TACHYON_QWEN35_MAX_DENSE_OPERATOR_BYTES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(512 * 1024 * 1024);
+        let working_set_bytes = std::env::var("TACHYON_QWEN35_WORKING_SET_BYTES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1024 * 1024 * 1024);
+        Ok(Self {
+            alias: alias.to_owned(),
+            root: root.to_path_buf(),
+            model,
+            config,
+            tokenizer,
+            chat_template,
+            max_dense_operator_bytes,
+            working_set: Mutex::new(LinearWorkingSet::new(working_set_bytes)),
+        })
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn generate(&self, prompts: &[&[u8]]) -> Result<Vec<u8>> {
+        let mut output = String::new();
+        self.generate_streaming(prompts, &mut |delta| output.push_str(delta))?;
+        Ok(output.into_bytes())
+    }
+
+    pub(crate) fn generate_streaming(
+        &self,
+        prompts: &[&[u8]],
+        on_token: &mut dyn FnMut(&str),
+    ) -> Result<()> {
+        if prompts.len() != 1 {
+            bail!("Qwen 3.5 MoE runtime currently accepts exactly one prompt per decode");
+        }
+        let request = self.parse_request(prompts[0])?;
+        let encoded = self
+            .tokenizer
+            .encode(request.prompt.clone(), true)
+            .map_err(|error| anyhow!("failed to tokenize Qwen prompt: {error}"))?;
+        if encoded.is_empty() {
+            bail!("Qwen prompt encoded to zero tokens");
+        }
+        if encoded.len() + request.max_new_tokens > self.config.max_position_embeddings {
+            bail!(
+                "prompt and generation length exceed context limit {}",
+                self.config.max_position_embeddings
+            );
+        }
+
+        let mut state = HybridDecodeState::new(&self.config.layer_types);
+        let mut logits = Vec::new();
+        for (position, token) in encoded.get_ids().iter().copied().enumerate() {
+            logits = self.forward_token(token, position, &mut state)?;
+        }
+        let sampling = resolve_sampling(
+            request.temperature,
+            request.top_p,
+            request.seed.unwrap_or(299_792_458),
+        );
+        let mut processor =
+            LogitsProcessor::from_sampling(request.seed.unwrap_or(299_792_458), sampling);
+        let mut generated = Vec::<u32>::new();
+        let mut emitted = 0usize;
+        for step in 0..request.max_new_tokens {
+            let tensor = Tensor::from_vec(logits, self.config.vocab_size, &Device::Cpu)?;
+            let token = processor.sample(&tensor)?;
+            if token == self.config.eos_token_id {
+                break;
+            }
+            generated.push(token);
+            let text = self
+                .tokenizer
+                .decode(&generated, true)
+                .map_err(|error| anyhow!("failed to decode Qwen tokens: {error}"))?;
+            let stop = request
+                .stop
+                .iter()
+                .filter_map(|needle| text.find(needle))
+                .min();
+            let safe_end = stop.unwrap_or(text.len());
+            if emitted < safe_end {
+                on_token(&text[emitted..safe_end]);
+                emitted = safe_end;
+            }
+            if stop.is_some() {
+                break;
+            }
+            logits = self.forward_token(token, encoded.len() + step, &mut state)?;
+        }
+        Ok(())
+    }
+
+    fn parse_request(&self, bytes: &[u8]) -> Result<ParsedRequest> {
+        if bytes.len() > 16_384 {
+            bail!("Qwen generation request exceeds 16384 bytes");
+        }
+        let raw = std::str::from_utf8(bytes).context("Qwen prompt must be UTF-8")?;
+        let request = if raw.trim_start().starts_with('{') {
+            serde_json::from_str::<GenerationRequest>(raw)
+                .context("invalid Qwen JSON generation request")?
+        } else {
+            GenerationRequest {
+                prompt: Some(raw.to_owned()),
+                messages: None,
+                max_new_tokens: default_max_new_tokens(),
+                temperature: None,
+                top_p: None,
+                seed: None,
+                stop: Vec::new(),
+            }
+        };
+        if request.max_new_tokens == 0 || request.max_new_tokens > HOST_MAX_NEW_TOKENS {
+            bail!("max_new_tokens must be between 1 and {HOST_MAX_NEW_TOKENS}");
+        }
+        let prompt = match (request.messages, request.prompt) {
+            (Some(messages), _) if messages.is_empty() => {
+                bail!("chat request must contain at least one message")
+            }
+            (Some(messages), _) => {
+                let messages = messages
+                    .into_iter()
+                    .map(|message| {
+                        let content = message.content.as_str().ok_or_else(|| {
+                            anyhow!(
+                                "Qwen 3.5 text runtime does not support image or structured message content"
+                            )
+                        })?;
+                        Ok(ChatTurn {
+                            role: message.role,
+                            content: content.to_owned(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                match &self.chat_template {
+                    Some(template) => template
+                        .render(&messages)
+                        .map_err(|error| anyhow!("failed to render Qwen chat template: {error}"))?,
+                    None => {
+                        let mut prompt = String::new();
+                        for message in messages {
+                            prompt.push_str(&message.role);
+                            prompt.push_str(": ");
+                            prompt.push_str(&message.content);
+                            prompt.push('\n');
+                        }
+                        prompt.push_str("assistant:");
+                        prompt
+                    }
+                }
+            }
+            (None, Some(prompt)) => prompt,
+            (None, None) => bail!("generation request requires `messages` or `prompt`"),
+        };
+        Ok(ParsedRequest {
+            prompt,
+            max_new_tokens: request.max_new_tokens,
+            temperature: request.temperature,
+            top_p: request.top_p,
+            seed: request.seed,
+            stop: request
+                .stop
+                .into_iter()
+                .filter(|stop| !stop.is_empty() && stop.len() <= 256)
+                .take(8)
+                .collect(),
+        })
+    }
+
+    fn forward_token(
+        &self,
+        token: u32,
+        position: usize,
+        state: &mut HybridDecodeState,
+    ) -> Result<Vec<f32>> {
+        let hidden_size = self.config.hidden_size;
+        let embedding = self
+            .model
+            .tensor_info("model.language_model.embed_tokens.weight")?;
+        let token = usize::try_from(token)?;
+        if token >= self.config.vocab_size {
+            bail!("token id {token} exceeds vocabulary");
+        }
+        let mut hidden = embedding.read_f32_slice(token * hidden_size, hidden_size)?;
+        for layer in 0..self.config.num_hidden_layers {
+            let prefix = format!("model.language_model.layers.{layer}");
+            let norm_weight = self
+                .model
+                .tensor_info(&format!("{prefix}.input_layernorm.weight"))?
+                .read_f32()?;
+            let normalized = rms_norm_qwen(&hidden, &norm_weight, self.config.rms_norm_eps as f32)?;
+            let mixed = match (&self.config.layer_types[layer], &mut state.layers[layer]) {
+                (LayerType::LinearAttention, LayerDecodeState::Linear(layer_state)) => {
+                    let qkv =
+                        self.linear(&format!("{prefix}.linear_attn.in_proj_qkv"), &normalized)?;
+                    let z = self.linear(&format!("{prefix}.linear_attn.in_proj_z"), &normalized)?;
+                    let b = self.linear(&format!("{prefix}.linear_attn.in_proj_b"), &normalized)?;
+                    let a = self.linear(&format!("{prefix}.linear_attn.in_proj_a"), &normalized)?;
+                    let conv = self
+                        .model
+                        .tensor_info(&format!("{prefix}.linear_attn.conv1d.weight"))?
+                        .read_f32()?;
+                    let a_log = self
+                        .model
+                        .tensor_info(&format!("{prefix}.linear_attn.A_log"))?
+                        .read_f32()?;
+                    let dt_bias = self
+                        .model
+                        .tensor_info(&format!("{prefix}.linear_attn.dt_bias"))?
+                        .read_f32()?;
+                    let gated_norm = self
+                        .model
+                        .tensor_info(&format!("{prefix}.linear_attn.norm.weight"))?
+                        .read_f32()?;
+                    let core = gated_delta_step(
+                        &qkv,
+                        &z,
+                        &b,
+                        &a,
+                        &conv,
+                        &a_log,
+                        &dt_bias,
+                        &gated_norm,
+                        self.config.linear_num_key_heads,
+                        self.config.linear_num_value_heads,
+                        self.config.linear_key_head_dim,
+                        self.config.linear_value_head_dim,
+                        self.config.linear_conv_kernel_dim,
+                        layer_state,
+                    )?;
+                    self.linear(&format!("{prefix}.linear_attn.out_proj"), &core)?
+                }
+                (LayerType::FullAttention, LayerDecodeState::Full(layer_state)) => {
+                    let query = self.linear(&format!("{prefix}.self_attn.q_proj"), &normalized)?;
+                    let key = self.linear(&format!("{prefix}.self_attn.k_proj"), &normalized)?;
+                    let value = self.linear(&format!("{prefix}.self_attn.v_proj"), &normalized)?;
+                    let q_norm = self
+                        .model
+                        .tensor_info(&format!("{prefix}.self_attn.q_norm.weight"))?
+                        .read_f32()?;
+                    let k_norm = self
+                        .model
+                        .tensor_info(&format!("{prefix}.self_attn.k_norm.weight"))?
+                        .read_f32()?;
+                    let core = full_attention_step(
+                        &query,
+                        &key,
+                        &value,
+                        &q_norm,
+                        &k_norm,
+                        self.config.num_attention_heads,
+                        self.config.num_key_value_heads,
+                        self.config.head_dim,
+                        (self.config.head_dim as f64 * self.config.partial_rotary_factor) as usize,
+                        self.config.rope_parameters.rope_theta as f32,
+                        position,
+                        layer_state,
+                    )?;
+                    self.linear(&format!("{prefix}.self_attn.o_proj"), &core)?
+                }
+                _ => bail!("hybrid decode state does not match layer {layer}"),
+            };
+            add_assign(&mut hidden, &mixed)?;
+            let post_norm_weight = self
+                .model
+                .tensor_info(&format!("{prefix}.post_attention_layernorm.weight"))?
+                .read_f32()?;
+            let post_norm =
+                rms_norm_qwen(&hidden, &post_norm_weight, self.config.rms_norm_eps as f32)?;
+            let router = self.linear(&format!("{prefix}.mlp.gate"), &post_norm)?;
+            let shared_gate =
+                self.linear(&format!("{prefix}.mlp.shared_expert_gate"), &post_norm)?[0];
+            let moe = sparse_moe_forward(
+                &post_norm,
+                &router,
+                self.config.num_experts_per_tok,
+                |expert, input| self.mlp(&format!("{prefix}.mlp.experts.{expert}"), input),
+                |input| self.mlp(&format!("{prefix}.mlp.shared_expert"), input),
+                shared_gate,
+            )?;
+            add_assign(&mut hidden, &moe)?;
+        }
+        let final_norm = self
+            .model
+            .tensor_info("model.language_model.norm.weight")?
+            .read_f32()?;
+        let hidden = rms_norm_qwen(&hidden, &final_norm, self.config.rms_norm_eps as f32)?;
+        self.linear("lm_head", &hidden)
+    }
+
+    fn mlp(&self, prefix: &str, input: &[f32]) -> Result<Vec<f32>> {
+        let gate = self.linear(&format!("{prefix}.gate_proj"), input)?;
+        let up = self.linear(&format!("{prefix}.up_proj"), input)?;
+        let activated = gate
+            .into_iter()
+            .zip(up)
+            .map(|(gate, up)| primitives::silu(gate) * up)
+            .collect::<Vec<_>>();
+        self.linear(&format!("{prefix}.down_proj"), &activated)
+    }
+
+    fn linear(&self, base: &str, input: &[f32]) -> Result<Vec<f32>> {
+        let cached = self
+            .working_set
+            .lock()
+            .map_err(|_| anyhow!("Qwen working-set lock is poisoned"))?
+            .get(base);
+        let prepared = match cached {
+            Some(prepared) => prepared,
+            None => {
+                let prepared = Arc::new(
+                    self.model
+                        .modelopt_linear(base)?
+                        .prepare(Some(self.max_dense_operator_bytes))?,
+                );
+                self.working_set
+                    .lock()
+                    .map_err(|_| anyhow!("Qwen working-set lock is poisoned"))?
+                    .insert(base.to_owned(), prepared.clone());
+                prepared
+            }
+        };
+        prepared
+            .matvec(input)
+            .with_context(|| format!("Qwen operator `{base}` failed"))
+    }
+}
+
+#[derive(Debug)]
+struct ParsedRequest {
+    prompt: String,
+    max_new_tokens: usize,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    seed: Option<u64>,
+    stop: Vec<String>,
+}
+
+fn resolve_sampling(temperature: Option<f32>, top_p: Option<f32>, _seed: u64) -> Sampling {
+    let Some(temperature) = temperature.filter(|value| value.is_finite() && *value > 1e-7) else {
+        return Sampling::ArgMax;
+    };
+    match top_p.filter(|value| value.is_finite() && *value > 0.0 && *value < 1.0) {
+        Some(p) => Sampling::TopP {
+            p: f64::from(p),
+            temperature: f64::from(temperature),
+        },
+        None => Sampling::All {
+            temperature: f64::from(temperature),
+        },
+    }
+}
+
+fn add_assign(left: &mut [f32], right: &[f32]) -> Result<()> {
+    if left.len() != right.len() {
+        bail!(
+            "residual dimensions differ: {} and {}",
+            left.len(),
+            right.len()
+        );
+    }
+    for (left, right) in left.iter_mut().zip(right) {
+        *left += right;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QuantKind {
+    Dense,
+    Fp8,
+    Nvfp4,
+}
+
+fn declares_qwen35(config: &Value) -> bool {
+    let architecture_matches = config
+        .get("architectures")
+        .and_then(Value::as_array)
+        .is_some_and(|architectures| {
+            architectures
+                .iter()
+                .any(|value| value.as_str() == Some(ARCHITECTURE))
+        });
+    let outer_matches = config.get("model_type").and_then(Value::as_str) == Some(OUTER_MODEL_TYPE);
+    let text_matches = config
+        .get("text_config")
+        .and_then(|text| text.get("model_type"))
+        .and_then(Value::as_str)
+        == Some(TEXT_MODEL_TYPE);
+    architecture_matches && outer_matches && text_matches
+}
+
+fn validate_producer(model: &ModelOptNvfp4Directory) -> Result<()> {
+    let producer = model
+        .hf_quant_json()
+        .and_then(|value| value.get("producer"))
+        .context("Qwen 3.5 ModelOpt profile requires hf_quant_config.json producer metadata")?;
+    let name = producer.get("name").and_then(Value::as_str).unwrap_or("");
+    let version = producer
+        .get("version")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if name != ACCEPTED_PRODUCER || version != ACCEPTED_PRODUCER_VERSION {
+        bail!(
+            "compatibility profile `{QWEN35_MOE_PROFILE_V1}` accepts producer {ACCEPTED_PRODUCER} {ACCEPTED_PRODUCER_VERSION}, got `{name}` `{version}`"
+        );
+    }
+    Ok(())
+}
+
+fn validate_quantization_metadata(model: &ModelOptNvfp4Directory) -> Result<()> {
+    let quantization = model
+        .hf_quant_json()
+        .and_then(|value| value.get("quantization"))
+        .context("Qwen 3.5 ModelOpt profile requires quantization metadata")?;
+    let algorithm = quantization
+        .get("quant_algo")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let kv_algorithm = quantization
+        .get("kv_cache_quant_algo")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if algorithm != "MIXED_PRECISION" || kv_algorithm != "FP8" {
+        bail!(
+            "expected MIXED_PRECISION weights with FP8 KV cache, got `{algorithm}` and `{kv_algorithm}`"
+        );
+    }
+    let layers = quantization
+        .get("quantized_layers")
+        .and_then(Value::as_object)
+        .context("quantization.quantized_layers must be an object")?;
+    let supported = BTreeSet::from(["FP8", "W4A16_NVFP4"]);
+    let mut seen = BTreeMap::<&str, usize>::new();
+    for (name, metadata) in layers {
+        let algo = metadata
+            .get("quant_algo")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("quantized layer `{name}` is missing quant_algo"))?;
+        if !supported.contains(algo) {
+            bail!("quantized layer `{name}` uses unsupported algorithm `{algo}`");
+        }
+        if algo == "W4A16_NVFP4"
+            && metadata.get("group_size").and_then(Value::as_u64) != Some(NVFP4_BLOCK_SIZE as u64)
+        {
+            bail!("quantized layer `{name}` must use NVFP4 group size {NVFP4_BLOCK_SIZE}");
+        }
+        *seen.entry(algo).or_default() += 1;
+    }
+    if !seen.contains_key("FP8") || !seen.contains_key("W4A16_NVFP4") {
+        bail!("mixed-precision profile requires both FP8 and W4A16_NVFP4 operators");
+    }
+    Ok(())
+}
+
+fn require_tensor(model: &ModelOptNvfp4Directory, name: &str) -> Result<()> {
+    if model.contains_tensor(name) {
+        Ok(())
+    } else {
+        bail!("required Qwen 3.5 tensor `{name}` is missing")
+    }
+}
+
+fn require_tensor_shape(
+    model: &ModelOptNvfp4Directory,
+    name: &str,
+    expected: &[usize],
+) -> Result<()> {
+    require_tensor(model, name)?;
+    let tensor = model.tensor_info(name)?;
+    if tensor.info.shape != expected {
+        bail!(
+            "tensor `{name}` has shape {:?}, expected {expected:?}",
+            tensor.info.shape
+        );
+    }
+    Ok(())
+}
+
+fn validate_linear_kind(
+    model: &ModelOptNvfp4Directory,
+    base: &str,
+    expected: QuantKind,
+    out_dim: usize,
+    in_dim: usize,
+) -> Result<()> {
+    let (actual, shape) = match model.modelopt_linear(base)? {
+        ModelOptLinearTensors::Fp8(linear) => {
+            if linear.weight.info.dtype != SafetensorsDType::F8E4M3 {
+                bail!("FP8 operator `{base}` weight must use F8_E4M3");
+            }
+            if linear
+                .weight_scale
+                .tensor
+                .info
+                .shape
+                .iter()
+                .product::<usize>()
+                != 1
+            {
+                bail!("FP8 operator `{base}` weight_scale must be scalar");
+            }
+            if linear.weight_scale.tensor.info.dtype != SafetensorsDType::F32 {
+                bail!("FP8 operator `{base}` weight_scale must use F32");
+            }
+            if linear.input_scale.as_ref().is_some_and(|scale| {
+                scale.tensor.info.shape.iter().product::<usize>() != 1
+                    || scale.tensor.info.dtype != SafetensorsDType::F32
+            }) {
+                bail!("FP8 operator `{base}` input_scale must be an F32 scalar");
+            }
+            (QuantKind::Fp8, linear.weight.info.shape)
+        }
+        ModelOptLinearTensors::Nvfp4(linear) => {
+            if linear.packed_weight.tensor.info.dtype != SafetensorsDType::U8
+                || linear.block_scales.tensor.info.dtype != SafetensorsDType::F8E4M3
+                || linear.tensor_scale.tensor.info.dtype != SafetensorsDType::F32
+            {
+                bail!("NVFP4 operator `{base}` has invalid packed or scale dtypes");
+            }
+            let packed = &linear.packed_weight.tensor.info.shape;
+            (QuantKind::Nvfp4, vec![packed[0], packed[1] * 2])
+        }
+        ModelOptLinearTensors::Passthrough(linear) => (QuantKind::Dense, linear.tensor.info.shape),
+    };
+    if actual != expected {
+        bail!("operator `{base}` uses {actual:?}, expected {expected:?}");
+    }
+    let expected_shape = vec![out_dim, in_dim];
+    if shape != expected_shape {
+        bail!("operator `{base}` has shape {shape:?}, expected {expected_shape:?}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn architecture_detection_uses_metadata_not_directory_name() {
+        let config = serde_json::json!({
+            "architectures": [ARCHITECTURE],
+            "model_type": OUTER_MODEL_TYPE,
+            "text_config": {"model_type": TEXT_MODEL_TYPE}
+        });
+        assert!(declares_qwen35(&config));
+    }
+
+    #[test]
+    fn architecture_detection_fails_closed_for_semantic_variants() {
+        let config = serde_json::json!({
+            "architectures": ["OtherArchitecture"],
+            "model_type": OUTER_MODEL_TYPE,
+            "text_config": {"model_type": TEXT_MODEL_TYPE}
+        });
+        assert!(!declares_qwen35(&config));
+    }
+
+    #[test]
+    fn gated_installed_checkpoint_validates_complete_profile() {
+        let Ok(path) = std::env::var("TACHYON_QWEN35_MOE_NVFP4_DIR") else {
+            return;
+        };
+        let model = ModelOptNvfp4Directory::try_load("qwen35-probe", path)
+            .expect("checkpoint parser should succeed")
+            .expect("checkpoint should be detected as ModelOpt/NVFP4");
+        let matched = QWEN35_MOE_DESCRIPTOR
+            .inspect(&model)
+            .expect("installed checkpoint should match")
+            .expect("installed checkpoint should select Qwen 3.5");
+        assert_eq!(matched.kind, ArchitectureKind::Qwen35MoeText);
+        assert_eq!(matched.profile, QWEN35_MOE_PROFILE_V1);
+    }
+
+    #[test]
+    fn gated_installed_checkpoint_constructs_text_runtime() {
+        let Ok(path) = std::env::var("TACHYON_QWEN35_MOE_NVFP4_DIR") else {
+            return;
+        };
+        let runtime = Qwen35MoeRuntime::try_load("qwen35-probe", &path, "cpu")
+            .expect("runtime construction should succeed")
+            .expect("checkpoint should select the Qwen runtime");
+        assert_eq!(runtime.config.num_hidden_layers, 40);
+        assert_eq!(runtime.config.num_experts, 256);
+        assert!(runtime.chat_template.is_some());
+    }
+
+    #[test]
+    fn working_set_is_bounded_and_reports_cache_activity() {
+        let mut cache = LinearWorkingSet::new(8);
+        let first = Arc::new(PreparedLinear::Fp8 {
+            rows: 1,
+            cols: 4,
+            weight: vec![0; 4],
+            scale: 1.0,
+        });
+        let second = Arc::new(PreparedLinear::Fp8 {
+            rows: 1,
+            cols: 8,
+            weight: vec![0; 8],
+            scale: 1.0,
+        });
+        cache.insert("first".to_owned(), first);
+        assert!(cache.get("first").is_some());
+        cache.insert("second".to_owned(), second);
+        assert!(cache.resident_bytes <= cache.max_bytes);
+        assert_eq!(cache.stats.hits, 1);
+        assert!(cache.stats.transfers >= 2);
+        assert!(cache.stats.evictions >= 1);
+    }
+
+    #[test]
+    fn gated_installed_checkpoint_generates_buffered_and_streaming_text() {
+        if std::env::var("TACHYON_QWEN35_RUN_SLOW_PROBE").as_deref() != Ok("1") {
+            return;
+        }
+        let path = std::env::var("TACHYON_QWEN35_MOE_NVFP4_DIR")
+            .expect("slow probe requires TACHYON_QWEN35_MOE_NVFP4_DIR");
+        let runtime = Qwen35MoeRuntime::try_load("qwen35-probe", path, "cpu")
+            .expect("runtime construction")
+            .expect("Qwen runtime");
+        let request = br#"{"prompt":"Hi","max_new_tokens":1,"temperature":0}"#;
+
+        let host_memory_before = current_process_memory_bytes();
+        let gpu_memory_before = nvidia_memory_used_mib();
+        let started = std::time::Instant::now();
+        let buffered = runtime.generate(&[request]).expect("buffered generation");
+        let first_token_ms = started.elapsed().as_millis();
+        let mut streamed = String::new();
+        let decode_started = std::time::Instant::now();
+        runtime
+            .generate_streaming(&[request], &mut |delta| streamed.push_str(delta))
+            .expect("streaming generation");
+        let decode_ms = decode_started.elapsed().as_millis();
+
+        assert!(!buffered.is_empty());
+        assert_ne!(buffered, b"MOCK_LLM_RESPONSE");
+        assert_eq!(String::from_utf8(buffered).expect("UTF-8"), streamed);
+        let working_set = runtime.working_set.lock().expect("working set");
+        eprintln!(
+            "{}",
+            serde_json::json!({
+                "first_token_ms": first_token_ms,
+                "streaming_decode_ms": decode_ms,
+                "state_profile": "layer-wise-streaming",
+                "working_set_resident_bytes": working_set.resident_bytes,
+                "working_set_hits": working_set.stats.hits,
+                "working_set_misses": working_set.stats.misses,
+                "working_set_transfers": working_set.stats.transfers,
+                "working_set_evictions": working_set.stats.evictions,
+                "host_memory_before_bytes": host_memory_before,
+                "host_memory_after_bytes": current_process_memory_bytes(),
+                "gpu_memory_before_mib": gpu_memory_before,
+                "gpu_memory_after_mib": nvidia_memory_used_mib(),
+            })
+        );
+    }
+
+    fn current_process_memory_bytes() -> Option<u64> {
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(
+            sysinfo::ProcessesToUpdate::Some(&[sysinfo::Pid::from_u32(std::process::id())]),
+            true,
+        );
+        system
+            .process(sysinfo::Pid::from_u32(std::process::id()))
+            .map(sysinfo::Process::memory)
+    }
+
+    fn nvidia_memory_used_mib() -> Option<u64> {
+        let output = std::process::Command::new("nvidia-smi")
+            .args(["--query-gpu=memory.used", "--format=csv,noheader,nounits"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8(output.stdout)
+            .ok()?
+            .lines()
+            .next()?
+            .trim()
+            .parse()
+            .ok()
+    }
+}

--- a/core-host/src/host_core/integrity_config.rs
+++ b/core-host/src/host_core/integrity_config.rs
@@ -1630,7 +1630,7 @@ pub(crate) fn normalize_route_models(
             )
         })?;
         let path = model.path.trim();
-        if path.is_empty() {
+        if path.is_empty() && !model.dynamic {
             return Err(anyhow!(
                 "Integrity Validation Failed: route `{route_path}` model `{alias}` must include a non-empty `path`"
             ));
@@ -1643,8 +1643,8 @@ pub(crate) fn normalize_route_models(
                 path: path.to_owned(),
                 device: model.device,
                 qos: model.qos,
-                dynamic: false,
-                hardware_strategy: Default::default(),
+                dynamic: model.dynamic,
+                hardware_strategy: model.hardware_strategy,
             });
     }
 

--- a/core-host/src/host_core/tests/rate_limit_models.rs
+++ b/core-host/src/host_core/tests/rate_limit_models.rs
@@ -167,6 +167,59 @@ fn validate_integrity_config_normalizes_model_bindings() {
 }
 
 #[test]
+fn validate_integrity_config_preserves_dynamic_model_bindings_without_paths() {
+    let mut config = IntegrityConfig::default_sealed();
+    let mut route = IntegrityRoute::user("/v1/chat/completions");
+    route.models = vec![IntegrityModelBinding {
+        alias: " qwen-dynamic ".to_owned(),
+        path: String::new(),
+        device: ModelDevice::Cpu,
+        qos: RouteQos::Standard,
+        dynamic: true,
+        hardware_strategy: Default::default(),
+    }];
+    config.routes = vec![route];
+
+    let config = validate_integrity_config(config).expect("dynamic model bindings should validate");
+    let route = config
+        .sealed_route("/v1/chat/completions")
+        .expect("OpenAI chat route should stay available");
+
+    assert_eq!(
+        route.models,
+        vec![IntegrityModelBinding {
+            alias: "qwen-dynamic".to_owned(),
+            path: String::new(),
+            device: ModelDevice::Cpu,
+            qos: RouteQos::Standard,
+            dynamic: true,
+            hardware_strategy: Default::default(),
+        }]
+    );
+}
+
+#[test]
+fn validate_integrity_config_rejects_static_model_bindings_without_paths() {
+    let mut config = IntegrityConfig::default_sealed();
+    let mut route = IntegrityRoute::user("/v1/chat/completions");
+    route.models = vec![IntegrityModelBinding {
+        alias: "qwen-static".to_owned(),
+        path: String::new(),
+        device: ModelDevice::Cpu,
+        qos: RouteQos::Standard,
+        dynamic: false,
+        hardware_strategy: Default::default(),
+    }];
+    config.routes = vec![route];
+
+    let error = validate_integrity_config(config)
+        .expect_err("static model bindings without paths must be rejected");
+    assert!(error
+        .to_string()
+        .contains("must include a non-empty `path`"));
+}
+
+#[test]
 fn validate_integrity_config_rejects_duplicate_model_aliases_across_routes() {
     let mut first = IntegrityRoute::user("/api/guest-ai");
     first.models = vec![IntegrityModelBinding {

--- a/docs/ai-inference-candle-llm-runtime.md
+++ b/docs/ai-inference-candle-llm-runtime.md
@@ -69,5 +69,7 @@ with an actionable error. They do not fall back to `MOCK_LLM_RESPONSE`.
 ## NVFP4 Boundary
 
 ModelOpt/NVFP4 remains a separate loader and kernel capability. A detected
-NVFP4 directory is classified as non-mock and still returns the existing
-unsupported-execution error until a complete architecture runtime is wired.
+directory is never interpreted as Llama merely because it contains
+safetensors. The registered Qwen 3.5 MoE compatibility profile executes through
+its dedicated hybrid runtime; unmatched architectures return an explicit
+unsupported-architecture error.

--- a/docs/ai-inference-modelopt-nvfp4.md
+++ b/docs/ai-inference-modelopt-nvfp4.md
@@ -1,6 +1,8 @@
-# ModelOpt/NVFP4 Inference Primitives
+# ModelOpt/NVFP4 Inference
 
-Tachyon supports ModelOpt/NVFP4 as quantized tensor primitives, not as a complete causal-LLM runtime.
+Tachyon supports ModelOpt/NVFP4 tensor primitives and a versioned Qwen 3.5 MoE
+text runtime. NVFP4 is a weight encoding, not a generic architecture marker:
+unknown architectures fail closed.
 
 ## Supported Layout
 
@@ -18,7 +20,11 @@ Packed FP4 bytes must not be interpreted as `f32`.
 
 ## Fallback Dequantization
 
-The pure Rust fallback converts packed FP4 plus FP8 E4M3 scales into BF16 or F32 dense tensors. It validates NVFP4 block size, packed shape, scale shape, nibble order, tensor scale, and fallback memory limits.
+The pure Rust fallback can convert packed FP4 plus FP8 E4M3 scales into BF16 or
+F32 dense tensors. Quantized matvec execution consumes packed FP8 or NVFP4
+weights directly, keeping fallback memory bounded to the active operator. It
+validates block size, packed shape, scale shape, nibble order, tensor scale, and
+fallback memory limits.
 
 Fallback can be estimated for eager full-model dequantization or for a layer window. If estimated host RAM or accelerator memory exceeds configured limits, the runtime rejects fallback instead of silently loading an unsafe dense tensor set.
 
@@ -54,6 +60,13 @@ cargo test -p core-host --features "ai-inference nvfp4-cuda" modelopt_nvfp4
 
 The native source provides CUDA entrypoints for NVFP4 dequantization and an initial linear matmul kernel that consumes ModelOpt packed FP4 weights and FP8 E4M3 scales. CUTLASS headers are required to compile the native kernels so future block-scaled Tensor Core kernels can use the same ABI boundary.
 
-## Current Runtime Boundary
+## Architecture Runtime
 
-Detected ModelOpt/NVFP4 directories are registered as typed component sets and do not fall through to `MOCK_LLM_RESPONSE`. Inference for such aliases returns an explicit unsupported-execution error until a concrete architecture runtime or native kernel backend is configured.
+Detected ModelOpt/NVFP4 directories are registered as typed component sets and
+never fall through to `MOCK_LLM_RESPONSE`. Checkpoints matching
+`qwen3.5-moe-text-modelopt-0.44-v1` execute through the hybrid Qwen 3.5 runtime.
+Other architectures return an actionable compatibility error.
+
+The Qwen runtime pages only the current layer, selected routed experts, shared
+expert, and required attention state. See
+[`ai/qwen35-moe-nvfp4-reference.md`](ai/qwen35-moe-nvfp4-reference.md).

--- a/docs/ai/qwen35-moe-nvfp4-reference.md
+++ b/docs/ai/qwen35-moe-nvfp4-reference.md
@@ -1,0 +1,90 @@
+# Qwen 3.5 MoE NVFP4 runtime reference
+
+The runtime contract is based on the upstream Hugging Face implementation
+`transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py` and NVIDIA ModelOpt
+unified Hugging Face checkpoint metadata.
+
+Initial compatibility profile:
+
+- profile: `qwen3.5-moe-text-modelopt-0.44-v1`
+- architecture: `Qwen3_5MoeForConditionalGeneration`
+- outer model type: `qwen3_5_moe`
+- text model type: `qwen3_5_moe_text`
+- producer: `modelopt` version `0.44.0`
+- weight graph: mixed `FP8` and `W4A16_NVFP4`
+- NVFP4 group size: 16
+- KV-cache declaration: `FP8`
+
+The profile is fail-closed. A different producer version, layer type, routing
+rule, quantization algorithm, or tensor contract requires a new versioned
+profile and parity fixtures.
+
+## Reference equations
+
+Full attention uses normalized Q/K heads, partial rotary embedding, grouped KV
+heads, causal scaled dot-product attention, a sigmoid output gate carried in
+the doubled Q projection, then the output projection.
+
+Linear-attention layers implement Qwen's gated delta rule:
+
+1. Project Q/K/V and Z; apply depthwise causal convolution and SiLU.
+2. L2-normalize Q/K and repeat key heads to the value-head count.
+3. Compute `beta = sigmoid(b)` and
+   `g = -exp(A_log) * softplus(a + dt_bias)`.
+4. Decay the recurrent K/V state by `exp(g)`.
+5. Correct the value by the state lookup at K, scaled by beta.
+6. Rank-one update the recurrent state and read it at Q.
+7. Apply RMS normalization followed by the SiLU Z gate and output projection.
+
+Sparse MoE routing computes FP32 softmax probabilities, selects deterministic
+top-k experts, renormalizes selected probabilities to sum to one, executes only
+selected experts, and adds the sigmoid-gated shared expert. Each expert is
+`down(silu(gate(x)) * up(x))`.
+
+## Reusable Candle inventory
+
+Candle 0.10 provides dense tensor operations, RMSNorm, Qwen 3 full-attention
+building blocks, Qwen 3 MoE routing, fused MoE infrastructure, sampling,
+tokenization integration, and KV-cache examples. It does not provide the Qwen
+3.5 gated-delta hybrid architecture or ModelOpt mixed FP8/NVFP4 tensor mapping.
+Those remain Tachyon runtime responsibilities.
+
+Production NVFP4 CUDA kernels are capability-gated to SM100 or newer. Older
+GPUs may use only bounded layer/operator fallback and must reject execution
+when configured host or accelerator memory limits would be exceeded.
+
+Sources:
+
+- https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+- https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/llm_ptq
+
+Related tracking:
+
+- Tachyon architecture parity: https://github.com/astorise/Tachyon-Mesh/issues/228
+- Multimodal/VLM execution (not part of this text runtime):
+  https://github.com/astorise/Tachyon-Mesh/issues/238
+
+## Adding a compatible checkpoint
+
+Do not register a checkpoint from its directory name or from the presence of
+NVFP4 tensors alone. Add or extend a versioned descriptor only after validating
+architecture identifiers, ordered layer semantics, routing behavior, producer
+version, quantization assignments, and the exact tensor contract. A new
+semantic variant also requires deterministic intermediate-state and logits
+fixtures.
+
+## Fixture regeneration and qualification
+
+Run `scripts/export_qwen35_moe_fixtures.py` against a local trusted tiny model.
+The script uses `local_files_only=True` and never downloads CI artifacts. For
+the installed production checkpoint, set `TACHYON_QWEN35_MOE_NVFP4_DIR` and run
+the gated Rust profile test.
+
+Runtime controls:
+
+- `TACHYON_QWEN35_MAX_DENSE_OPERATOR_BYTES`: maximum dense fallback operator.
+- `TACHYON_QWEN35_WORKING_SET_BYTES`: bounded prepared-weight working set.
+- `TACHYON_MODEL_OPT_NVFP4_DIR`: generic ModelOpt parser probe.
+
+Contract failures identify the layer, expert, projection, tensor, shape, or
+quantization assignment that must be corrected.

--- a/examples/guest-openai/src/lib.rs
+++ b/examples/guest-openai/src/lib.rs
@@ -228,7 +228,16 @@ fn handle_chat_completions(body: &[u8]) -> Result<(u16, Vec<u8>), String> {
         return Err("chat completion request must include at least one message".to_owned());
     }
 
-    let model_id = match bindings::tachyon::accelerator::cpu::load_model(&request.model) {
+    let models = list_models()?;
+    let Some(alias) = resolve_model_alias(&request.model, &models) else {
+        return Ok(openai_error_payload(
+            404,
+            format!("model `{}` is unavailable", request.model),
+            "model_not_found",
+        ));
+    };
+
+    let model_id = match bindings::tachyon::accelerator::cpu::load_model(alias) {
         Ok(model_id) => model_id,
         Err(error) => {
             return Ok(openai_error_payload(
@@ -244,6 +253,15 @@ fn handle_chat_completions(body: &[u8]) -> Result<(u16, Vec<u8>), String> {
     } else {
         handle_chat_completions_buffered(request, model_id)
     }
+}
+
+fn resolve_model_alias<'a>(requested: &str, models: &'a [ModelInfo]) -> Option<&'a str> {
+    models
+        .iter()
+        .find(|model| {
+            model.alias == requested || format!("{}/{}", model.engine, model.alias) == requested
+        })
+        .map(|model| model.alias.as_str())
 }
 
 fn handle_chat_completions_buffered(
@@ -492,6 +510,26 @@ mod tests {
         // validation, before any host accelerator import is invoked.
         let result = route_request("POST", ROUTE_CHAT_COMPLETIONS, b"{}");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolves_openai_model_id_to_registry_alias() {
+        let models = vec![ModelInfo {
+            alias: "nvidia--Qwen3.6-35B-A3B-NVFP4".to_owned(),
+            engine: "safetensors".to_owned(),
+            vram_required_mb: 0,
+            status: "available".to_owned(),
+        }];
+
+        assert_eq!(
+            resolve_model_alias("safetensors/nvidia--Qwen3.6-35B-A3B-NVFP4", &models),
+            Some("nvidia--Qwen3.6-35B-A3B-NVFP4")
+        );
+        assert_eq!(
+            resolve_model_alias("nvidia--Qwen3.6-35B-A3B-NVFP4", &models),
+            Some("nvidia--Qwen3.6-35B-A3B-NVFP4")
+        );
+        assert_eq!(resolve_model_alias("unknown", &models), None);
     }
 
     #[test]

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/.openspec.yaml
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/design.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/design.md
@@ -1,0 +1,162 @@
+## Context
+
+The current runtime has three separate pieces that do not yet form an
+end-to-end NVFP4 text-generation engine:
+
+- `candle_llm_runtime.rs` implements buffered and streaming generation, chat
+  templates, sampling, stop handling, and decode state, but only for supported
+  dense Llama-family models.
+- `modelopt_nvfp4.rs` validates sharded ModelOpt checkpoints and exposes typed
+  FP8/NVFP4 tensor components.
+- `modelopt_nvfp4_cuda.rs` and the CUDA/CUTLASS source expose initial
+  capability-gated dequantization and linear kernels, but no model architecture
+  forward pass.
+
+The installed checkpoint is labelled Qwen 3.6 but declares
+`Qwen3_5MoeForConditionalGeneration`, `model_type=qwen3_5_moe`, and
+`text_config.model_type=qwen3_5_moe_text`. Its text tower has 40 layers:
+30 linear-attention layers and 10 full-attention layers, 256 routed experts,
+8 selected experts per token, shared experts, FP8 attention projections,
+W4A16 NVFP4 expert/LM-head weights, and FP8 KV-cache metadata. It also includes
+vision configuration, but the requested OpenAI path is text generation.
+
+GitHub issue #228 tracks broad architecture parity. This change is the focused,
+implementable slice for the Qwen 3.5-compatible hybrid-MoE ModelOpt contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce correct text generation for the installed checkpoint through the
+  existing accelerator and OpenAI streaming paths.
+- Support other checkpoints whose architecture descriptor and tensor contract
+  match a registered Qwen 3.5-compatible profile.
+- Compose FP8 and NVFP4 operators without eagerly densifying the full model.
+- Preserve CPU correctness fallback for small fixtures and native acceleration
+  for production-sized checkpoints.
+- Keep architecture recognition explicit and fail closed for unknown variants.
+
+**Non-Goals:**
+
+- Vision/image input or execution of the vision tower.
+- Generic support for every Qwen, MoE, or ModelOpt checkpoint.
+- MTP/speculative decoding in the first implementation.
+- Unbounded CPU execution of the 35B production checkpoint.
+- Replacing the existing Llama, ONNX, or mock backends.
+
+## Decisions
+
+### 1. Separate architecture semantics from weight representation
+
+Add an architecture registry that maps normalized model metadata to an
+`ArchitectureDescriptor` and constructs a backend implementing the existing
+buffered/streaming generation interface. The first descriptor accepts the
+Qwen 3.5 MoE text contract and validates:
+
+- accepted `model_type` / architecture identifiers;
+- hybrid layer types and required configuration fields;
+- embedding, normalization, attention, MoE, and LM-head tensor-name patterns;
+- supported quantization assignment per operator;
+- excluded unsupported components such as MTP and vision.
+
+This is preferred over treating all NVFP4 checkpoints as compatible: NVFP4
+describes weight encoding, not the forward graph.
+
+### 2. Implement a text-only Qwen 3.5 hybrid decoder
+
+The runtime owns:
+
+- token embeddings and final normalization;
+- full-attention layers with causal masking, grouped KV heads, partial rotary
+  dimensions, and KV-cache state;
+- linear-attention layers with their convolution/recurrent state and gated
+  output projections;
+- sparse MoE router logits, deterministic top-k selection, routing-weight
+  normalization, routed experts, shared expert, and aggregation;
+- LM-head logits and reuse of existing sampling/streaming logic.
+
+The exact equations and tensor transforms must be validated against a trusted
+reference implementation and fixture outputs before the production checkpoint
+is enabled.
+
+### 3. Use operator-level mixed precision
+
+Introduce quantized linear dispatch behind one operator contract:
+
+- BF16/F16/F32 passthrough tensors use Candle dense operators;
+- FP8 ModelOpt tensors use validated block scales and input scales;
+- W4A16 NVFP4 tensors use existing packed weights, block scales, tensor scales,
+  and optional activation scales;
+- native CUDA/CUTLASS kernels are selected only when capabilities match;
+- fallback dequantization is limited to the active operator/layer window.
+
+This avoids constructing one dense copy of all 256 experts.
+
+### 4. Make memory profile part of execution, not only loading
+
+`performance` may retain a bounded working set of frequently selected experts
+and layers. `layer-wise-streaming` maps shards and pages only active layer and
+selected expert tensors. Full-attention KV cache and linear-attention recurrent
+state are accounted separately and may be offloaded according to the existing
+memory-profile contract.
+
+### 5. Stage correctness before optimization
+
+Implementation proceeds in gates:
+
+1. metadata/tensor-contract validation;
+2. tiny unquantized or synthetic mixed-precision fixture;
+3. deterministic single-token forward parity;
+4. multi-token state and streaming parity;
+5. per-operator FP8/NVFP4 fallback;
+6. native CUDA kernels and memory-profile integration;
+7. opt-in installed-checkpoint smoke.
+
+The production route is not enabled until the installed-checkpoint probe
+generates non-mock output within explicit memory limits.
+
+### 6. Dependency strategy
+
+First inspect Candle 0.10 and the `astorise/candle` fork for reusable Qwen 3.5,
+linear-attention, MoE, FP8, and cache primitives. Missing primitives are added
+to the fork only when they are generally reusable; Tachyon-specific model
+assembly and ModelOpt tensor mapping remain in `core-host`.
+
+## Risks / Trade-offs
+
+- [The checkpoint architecture is newer than Candle support] → Start with a
+  dependency spike and isolate reusable primitives in the Candle fork.
+- [Hybrid linear-attention state is implemented incorrectly] → Require
+  layer-level golden fixtures and multi-token reference parity.
+- [256 experts cause excessive open mappings or host memory] → Lazy-map shards,
+  cache bounded tensor headers, and load only top-k plus shared experts.
+- [Fallback dequantization is too large for the installed model] → Restrict
+  fallback to tests/small models and require native capability for the 35B
+  production checkpoint.
+- [Mixed FP8/NVFP4 scaling semantics differ across ModelOpt versions] → Validate
+  producer version and quantized-layer metadata, and reject unknown contracts.
+- [Vision tensors are accidentally required] → Build from the text config and
+  text tensor namespace only; reject multimodal request content explicitly.
+- [Model naming suggests Qwen 3.6 while config says 3.5] → Compatibility is
+  determined from normalized metadata and tensors, never the directory name.
+
+## Migration Plan
+
+1. Land architecture and operator fixtures without changing deployed routes.
+2. Enable the new backend under `ai-inference`; keep native CUDA separately
+   feature/capability gated.
+3. Run the opt-in installed-checkpoint probe on the HomeLab node.
+4. Add the model's dynamic binding to `/v1/chat/completions`.
+5. Verify buffered and streaming OpenAI responses through
+   `https://ai.tachyon-mesh.wsl/v1`.
+
+Rollback removes the route binding or disables the architecture descriptor;
+other model backends remain unchanged.
+
+## Open Questions
+
+- Which trusted reference implementation and fixture exporter will define
+  golden intermediate tensors for Qwen 3.5 linear attention?
+- Does the installed GPU expose native FP4 capability required for acceptable
+  35B latency, or is a different optimized kernel path required?
+- Which ModelOpt producer versions beyond 0.44.0 should be accepted initially?

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/proposal.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+Tachyon detects and validates ModelOpt/NVFP4 checkpoints but still has no
+complete architecture runtime for them. The installed
+`nvidia--Qwen3.6-35B-A3B-NVFP4` checkpoint is therefore listed by the OpenAI API
+but rejected because its actual architecture is `qwen3_5_moe`, not Llama.
+
+This is a concrete specialization of GitHub issue
+[#228](https://github.com/astorise/Tachyon-Mesh/issues/228), which tracks broad
+Qwen/Gemma/Phi/DeepSeek architecture support but does not specify the hybrid
+Qwen 3.5 MoE and mixed FP8/NVFP4 execution contract required here.
+
+## What Changes
+
+- Add a text-generation runtime for the Hugging Face
+  `Qwen3_5MoeForConditionalGeneration` /
+  `qwen3_5_moe_text` architecture.
+- Implement its hybrid sequence of linear-attention and full-attention layers,
+  rotary-position behavior, gated projections, RMS normalization, vocabulary
+  projection, and autoregressive KV/recurrent state.
+- Implement sparse MoE routing for configurable expert counts, top-k experts
+  per token, shared experts, and expert aggregation.
+- Execute ModelOpt mixed-precision checkpoints where attention projections are
+  FP8 and MoE/shared-expert/LM-head weights are W4A16 NVFP4.
+- Reuse the existing typed safetensors index, NVFP4 dequantization, native
+  CUDA/CUTLASS capability gates, sampling, chat-template, stop, streaming, and
+  OpenAI response paths.
+- Introduce an architecture descriptor/registry so additional checkpoints can
+  use this runtime when their declared architecture, layer semantics,
+  quantization metadata, and tensor-name contract are compatible.
+- Reject merely “NVFP4” models whose architecture or tensor contract is not
+  implemented, with an actionable compatibility error.
+- Add deterministic small fixtures and an opt-in probe for the installed
+  checkpoint; CI SHALL NOT download large external model artifacts.
+- Keep vision inputs and the Qwen vision tower out of scope; those remain
+  covered by GitHub issue
+  [#238](https://github.com/astorise/Tachyon-Mesh/issues/238).
+
+## Capabilities
+
+### New Capabilities
+
+- `qwen35-moe-runtime`: Hybrid-attention sparse-MoE text generation for
+  Qwen 3.5-compatible checkpoints.
+
+### Modified Capabilities
+
+- `ai-inference`: ModelOpt/NVFP4 aliases with a supported architecture execute
+  real buffered and streaming generation rather than the unsupported boundary.
+- `modelopt-nvfp4-kernels`: Mixed FP8/NVFP4 architecture execution composes the
+  existing typed quantized components and capability-gated kernels.
+- `ai-layer-wise-inference`: Large compatible MoE checkpoints preserve
+  memory-profile semantics without loading every expert and layer onto the
+  accelerator simultaneously.
+
+## Impact
+
+- `core-host/src/ai_inference` architecture loading, decode state, batching,
+  quantized linear operators, and CUDA integration.
+- Potential additions to the `astorise/candle` fork if Candle 0.10 lacks the
+  required Qwen 3.5 hybrid-attention or sparse-MoE primitives.
+- Model broker compatibility metadata and runtime diagnostics.
+- OpenAI `/v1/chat/completions` becomes usable for the installed checkpoint once
+  the route binding change is also deployed.
+- Significant GPU-memory, host-memory, correctness, and performance testing.

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/ai-inference/spec.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/ai-inference/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: AI inference bindings MUST classify ModelOpt/NVFP4 directories without mock execution
+
+The AI inference runtime SHALL load supported ModelOpt/NVFP4 model bindings as
+typed component sets and SHALL NOT return mock inference output for those
+aliases. When a registered architecture backend matches the checkpoint, the
+runtime SHALL execute real inference; otherwise it SHALL return an actionable
+unsupported-architecture error.
+
+#### Scenario: Detected NVFP4 alias executes with a supported architecture
+
+- **WHEN** a preloaded model alias is classified as ModelOpt/NVFP4
+- **AND** a registered architecture backend validates its metadata and tensors
+- **THEN** inference executes through that architecture backend
+- **AND** the response is not `MOCK_LLM_RESPONSE`
+
+#### Scenario: Detected NVFP4 alias refuses an unsupported architecture
+
+- **WHEN** a preloaded model alias is classified as ModelOpt/NVFP4
+- **AND** no registered architecture backend accepts it
+- **THEN** the runtime returns an actionable unsupported-architecture error
+- **AND** the response is not `MOCK_LLM_RESPONSE`
+
+#### Scenario: Existing ONNX guest path remains available
+
+- **WHEN** a legacy guest loads an ONNX model through WASI-NN
+- **THEN** the host continues to use the candle-onnx backend
+- **AND** ModelOpt/NVFP4 loading does not change the ONNX graph encoding contract
+
+### Requirement: Existing ONNX and NVFP4 boundaries MUST remain unchanged
+
+Adding a new ModelOpt/NVFP4 architecture runtime SHALL NOT change legacy Candle
+ONNX/WASI-NN graph loading. NVFP4 checkpoints SHALL execute only when an
+explicit architecture backend validates their metadata and tensor contract;
+all other NVFP4 checkpoints SHALL preserve the non-mock unsupported boundary.
+
+#### Scenario: Legacy ONNX guest still uses candle-onnx
+
+- **WHEN** a legacy guest loads an ONNX model through WASI-NN
+- **THEN** the host continues to use the candle-onnx backend
+- **AND** architecture backend selection does not change the ONNX graph
+  encoding contract
+
+#### Scenario: Supported ModelOpt/NVFP4 alias generates text
+
+- **WHEN** a preloaded ModelOpt/NVFP4 alias matches a registered text-generation
+  architecture backend
+- **THEN** buffered and streaming inference execute real model generation
+- **AND** the response is not `MOCK_LLM_RESPONSE`
+
+#### Scenario: Unsupported ModelOpt/NVFP4 alias remains non-mock
+
+- **WHEN** a preloaded model alias is classified as ModelOpt/NVFP4
+- **AND** no architecture backend is configured for that alias
+- **THEN** inference returns an actionable unsupported-execution error
+- **AND** the response is not `MOCK_LLM_RESPONSE`
+
+### Requirement: The runtime streams decoded fragments incrementally
+
+The runtime SHALL provide a streaming generation path that emits each newly
+decoded text fragment as it is produced, such that the concatenation of all
+fragments equals the buffered generation output for the same request. While
+streaming with stop sequences, the runtime SHALL hold back the trailing text
+that could begin a stop match until a further token confirms it is safe to emit.
+
+#### Scenario: Streamed fragments reconstruct the buffered output
+
+- **WHEN** the same request is run buffered and streamed
+- **THEN** the streamed path emits one or more fragments
+- **AND** their concatenation equals the buffered output byte-for-byte
+
+#### Scenario: Non-generative backends fall back to a single fragment
+
+- **WHEN** a streaming request targets a backend that cannot decode
+  incrementally, such as an explicit mock backend
+- **THEN** the runtime emits the entire output as one fragment
+
+#### Scenario: Supported NVFP4 architecture streams tokens
+
+- **WHEN** a streaming request targets a ModelOpt/NVFP4 checkpoint with a
+  registered autoregressive architecture backend
+- **THEN** decoded text fragments are emitted incrementally as tokens are
+  generated

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/ai-layer-wise-inference/spec.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/ai-layer-wise-inference/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Layer-wise sparse-MoE execution MUST page only active experts
+
+For compatible Qwen 3.5 MoE checkpoints, layer-wise streaming SHALL map and
+transfer only the active layer, selected routed experts, shared expert, and
+required attention state.
+
+#### Scenario: Inactive experts remain off accelerator
+
+- **WHEN** a token selects a subset of experts in layer-wise mode
+- **THEN** non-selected experts for that layer remain outside accelerator
+  memory
+
+#### Scenario: Sharded experts resolve through the tensor index
+
+- **WHEN** selected experts span multiple safetensors shards
+- **THEN** each expert tensor is resolved by name through
+  `model.safetensors.index.json`
+
+### Requirement: Hybrid attention state MUST respect memory profiles
+
+The memory-profile implementation SHALL account separately for full-attention
+KV cache and linear-attention recurrent state.
+
+#### Scenario: Full-attention cache is paged
+
+- **WHEN** layer-wise decode leaves a full-attention layer
+- **THEN** its KV cache is retained or offloaded according to the configured
+  memory profile without losing autoregressive state
+
+#### Scenario: Linear-attention state is paged
+
+- **WHEN** layer-wise decode leaves a linear-attention layer
+- **THEN** its convolutional or recurrent state is retained or offloaded
+  according to the configured memory profile

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/modelopt-nvfp4-kernels/spec.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/modelopt-nvfp4-kernels/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Mixed FP8 and NVFP4 operators MUST compose in one forward graph
+
+The ModelOpt runtime SHALL execute a single architecture graph containing dense
+BF16/F16 tensors, FP8 projections, and W4A16 NVFP4 projections according to the
+checkpoint's quantized-layer metadata.
+
+#### Scenario: Operator selects declared quantization
+
+- **WHEN** quantization metadata assigns FP8, W4A16 NVFP4, or dense storage to an
+  operator
+- **THEN** the runtime dispatches that operator through the matching typed
+  implementation
+
+#### Scenario: Unknown mixed-precision assignment is rejected
+
+- **WHEN** quantization metadata assigns an unsupported algorithm to a required
+  operator
+- **THEN** loading fails with the operator name and quantization algorithm
+
+### Requirement: NVFP4 sparse experts MUST avoid full-model densification
+
+The runtime SHALL execute selected NVFP4 experts without eagerly dequantizing
+all experts or all layers into dense accelerator tensors.
+
+#### Scenario: Only active experts are materialized
+
+- **WHEN** sparse routing selects a subset of experts
+- **THEN** only those experts and shared experts are transferred, dequantized,
+  or executed for that token batch
+
+#### Scenario: Fallback is memory bounded
+
+- **WHEN** native NVFP4 expert kernels are unavailable
+- **THEN** fallback dequantization is limited to the active expert/layer window
+- **AND** execution is rejected when configured host or accelerator memory
+  limits would be exceeded
+
+### Requirement: Native mixed-precision execution MUST remain capability-gated
+
+Production-sized compatible checkpoints SHALL use native FP8/NVFP4 kernels only
+when hardware, runtime, and compiled-kernel capabilities satisfy the operator
+requirements.
+
+#### Scenario: Production checkpoint lacks required native capability
+
+- **WHEN** a checkpoint exceeds the configured fallback memory threshold
+- **AND** required native FP8 or NVFP4 kernels are unavailable
+- **THEN** the runtime rejects execution with the missing capabilities
+
+#### Scenario: Compatible native backend executes packed weights
+
+- **WHEN** the accelerator reports all required native capabilities
+- **THEN** packed FP8/NVFP4 weights execute without full eager dense conversion

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/qwen35-moe-runtime/spec.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/specs/qwen35-moe-runtime/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Runtime MUST recognize compatible Qwen 3.5 MoE text architectures
+
+The runtime SHALL recognize Qwen 3.5-compatible MoE text checkpoints from
+normalized model metadata and tensor contracts, not from directory names.
+
+#### Scenario: Compatible architecture is selected
+
+- **WHEN** a checkpoint declares a supported Qwen 3.5 MoE architecture and text
+  configuration
+- **AND** its required tensor names and shapes match the registered descriptor
+- **THEN** the runtime selects the Qwen 3.5 MoE text backend
+
+#### Scenario: NVFP4 alone is insufficient
+
+- **WHEN** a checkpoint uses ModelOpt NVFP4 but its architecture or tensor
+  contract does not match a registered descriptor
+- **THEN** the runtime rejects it with an actionable architecture-compatibility
+  error
+
+#### Scenario: Directory marketing name differs from metadata
+
+- **WHEN** the model directory or registry alias names a different Qwen release
+- **THEN** backend selection SHALL use `config.json`, text configuration,
+  quantization metadata, and indexed tensors
+
+### Requirement: Runtime MUST execute hybrid linear and full attention
+
+The Qwen 3.5 MoE backend SHALL execute the declared ordered sequence of
+linear-attention and full-attention decoder layers with the required gated
+projections and position encoding.
+
+#### Scenario: Hybrid layer schedule is preserved
+
+- **WHEN** the configuration declares a mixture of linear-attention and
+  full-attention layer types
+- **THEN** each layer executes the operator type declared at its index
+- **AND** hidden states flow through the layers in declaration order
+
+#### Scenario: Full attention maintains KV state
+
+- **WHEN** autoregressive decode crosses a full-attention layer
+- **THEN** the backend updates and reuses causal key/value cache state for that
+  layer
+
+#### Scenario: Linear attention maintains recurrent state
+
+- **WHEN** autoregressive decode crosses a linear-attention layer
+- **THEN** the backend updates and reuses the convolutional or recurrent state
+  required by that layer
+
+### Requirement: Runtime MUST execute sparse routed and shared experts
+
+The backend SHALL compute router logits, select the configured number of
+experts per token, normalize routing weights according to the architecture,
+execute only selected routed experts plus the shared expert, and aggregate
+their outputs.
+
+#### Scenario: Top-k routing is deterministic
+
+- **WHEN** router logits are equal across repeated deterministic runs
+- **THEN** the same expert indices and routing weights are selected
+
+#### Scenario: Only selected experts execute
+
+- **WHEN** a layer declares many experts and a smaller `num_experts_per_tok`
+- **THEN** the forward pass executes only the selected routed experts for each
+  token plus configured shared experts
+
+#### Scenario: Invalid expert tensors are rejected
+
+- **WHEN** an expert group is missing a required gate, up, down, scale, or
+  activation component
+- **THEN** model loading fails with the layer index, expert index, and missing
+  component
+
+### Requirement: Runtime MUST provide bounded text generation
+
+The backend SHALL reuse Tachyon's chat-template, tokenization, sampling, stop,
+buffered generation, and incremental streaming contracts.
+
+#### Scenario: Buffered generation produces real text
+
+- **WHEN** a valid prompt targets a compatible checkpoint
+- **THEN** the backend returns generated UTF-8 text that is not mock output
+
+#### Scenario: Streaming reconstructs buffered output
+
+- **WHEN** equivalent deterministic requests are run buffered and streamed
+- **THEN** concatenated streamed fragments equal the buffered generated text
+
+#### Scenario: Vision input remains unsupported
+
+- **WHEN** a request supplies image content to the text-only backend
+- **THEN** the runtime rejects it with an explicit unsupported-modality error
+
+### Requirement: Compatibility profile MUST be extensible and fail closed
+
+The architecture registry SHALL permit additional checkpoint variants to reuse
+the backend only when a versioned compatibility profile validates their model
+metadata, operator semantics, quantization assignments, and tensor contract.
+
+#### Scenario: Compatible sibling checkpoint is accepted
+
+- **WHEN** another checkpoint matches a registered compatibility profile despite
+  different layer or expert counts
+- **THEN** the runtime parameterizes the same backend from its configuration
+
+#### Scenario: Semantic variant is rejected
+
+- **WHEN** a checkpoint introduces an unknown layer type, router rule, position
+  encoding, or quantization assignment
+- **THEN** the runtime rejects it until a new compatibility profile is
+  implemented and tested

--- a/openspec/changes/add-qwen35-moe-nvfp4-runtime/tasks.md
+++ b/openspec/changes/add-qwen35-moe-nvfp4-runtime/tasks.md
@@ -1,0 +1,70 @@
+## 1. Reference Contract and Dependency Spike
+
+- [x] 1.1 Inventory reusable Qwen 3.5, hybrid-attention, sparse-MoE, FP8, and cache primitives in Candle 0.10 and the `astorise/candle` fork
+- [x] 1.2 Select a trusted Qwen 3.5 reference implementation and document the exact linear-attention, rotary, routing, and shared-expert equations
+- [x] 1.3 Add a reproducible exporter for small golden configuration, tensor, intermediate-state, and logits fixtures without downloading production model artifacts in CI
+- [x] 1.4 Record the accepted ModelOpt producer version and mixed-precision metadata contract for the first compatibility profile
+
+## 2. Architecture Detection and Validation
+
+- [x] 2.1 Add an architecture descriptor and registry for text-generation backends
+- [x] 2.2 Implement normalized recognition of `Qwen3_5MoeForConditionalGeneration`, `qwen3_5_moe`, and `qwen3_5_moe_text` metadata
+- [x] 2.3 Validate the hybrid layer schedule, dimensions, rotary settings, expert counts, top-k routing, shared-expert settings, and unsupported MTP or vision requirements
+- [x] 2.4 Validate required tensor names, shapes, shard-index entries, and per-operator quantization assignments with actionable errors
+- [x] 2.5 Add fail-closed compatibility-profile versioning for sibling checkpoints with compatible semantics but different layer or expert counts
+
+## 3. Hybrid Decoder Runtime
+
+- [x] 3.1 Implement token embedding, RMS normalization, residual flow, final normalization, and LM-head projection for the Qwen 3.5 text tower
+- [x] 3.2 Implement full-attention layers with grouped KV heads, causal masking, partial rotary dimensions, and autoregressive KV-cache updates
+- [x] 3.3 Implement linear-attention layers with the required gated projections, convolutional state, recurrent state, and token-by-token updates
+- [x] 3.4 Dispatch each decoder layer according to the declared ordered hybrid layer schedule
+- [x] 3.5 Add deterministic single-token and multi-token golden parity tests for full-attention, linear-attention, and complete decoder layers
+
+## 4. Sparse MoE Execution
+
+- [x] 4.1 Implement router logits, deterministic top-k expert selection, routing-weight normalization, and output aggregation
+- [x] 4.2 Implement routed expert gate, up, activation, and down projections using configurable expert counts
+- [x] 4.3 Implement shared-expert execution and aggregation with routed expert outputs
+- [x] 4.4 Resolve selected expert tensors lazily across safetensors shards and report layer, expert, and component on contract failures
+- [x] 4.5 Add golden routing and expert-output tests, including ties, multiple tokens, and missing tensor components
+
+## 5. Mixed FP8 and NVFP4 Operators
+
+- [x] 5.1 Introduce a quantized-linear operator contract that dispatches dense, FP8, and W4A16 NVFP4 storage from validated metadata
+- [x] 5.2 Implement the FP8 projection path with block scales, input scales, dtype validation, and deterministic fallback tests
+- [x] 5.3 Integrate packed W4A16 NVFP4 expert, shared-expert, and LM-head projections with tensor and block scales
+- [x] 5.4 Bound fallback dequantization to the active operator or layer window and reject execution before configured memory limits are exceeded
+- [x] 5.5 Gate native FP8 and NVFP4 CUDA/CUTLASS paths on compiled kernels, runtime support, GPU capability, alignment, and shape constraints
+- [x] 5.6 Add mixed dense/FP8/NVFP4 forward-graph parity tests and unsupported quantization diagnostics
+
+## 6. Decode State and Memory Profiles
+
+- [x] 6.1 Extend decode state to track full-attention KV caches separately from linear-attention convolutional and recurrent state
+- [x] 6.2 Account for both state types in performance and layer-wise-streaming memory plans
+- [x] 6.3 Page only the active layer, selected routed experts, shared expert, and required state in layer-wise-streaming mode
+- [x] 6.4 Add bounded expert and layer working-set caches with observable hit, miss, transfer, and eviction diagnostics
+- [x] 6.5 Add tests proving inactive experts remain off accelerator memory and state survives layer paging across multiple decode tokens
+
+## 7. Generation and OpenAI Integration
+
+- [x] 7.1 Connect the Qwen 3.5 backend to the existing tokenizer, chat template, sampling, stop-sequence, and bounded generation pipeline
+- [x] 7.2 Implement incremental streaming through the existing OpenAI response path and verify streamed fragments reconstruct deterministic buffered output
+- [x] 7.3 Reject image content and unsupported modalities explicitly while retaining text-only requests
+- [x] 7.4 Preserve the existing ONNX, Llama, mock, and unsupported-NVFP4 backend boundaries in regression tests
+- [x] 7.5 Add model-broker compatibility metadata and diagnostics that distinguish weight format support from architecture runtime support
+
+## 8. Production Checkpoint Qualification
+
+- [x] 8.1 Add an opt-in local probe for `models/nvidia--Qwen3.6-35B-A3B-NVFP4` that validates metadata and tensors without eager model densification
+- [x] 8.2 Add an opt-in deterministic prompt test that produces non-mock text through buffered and streaming runtime paths
+- [x] 8.3 Measure host memory, accelerator memory, first-token latency, decode latency, and expert paging for each supported memory profile
+- [x] 8.4 Require native production capabilities when fallback execution would exceed configured memory limits and verify the resulting diagnostic
+- [ ] 8.5 Bind the qualified model to the deployed OpenAI route and smoke-test `https://ai.tachyon-mesh.wsl/v1/chat/completions`
+
+## 9. Documentation and Release Guardrails
+
+- [x] 9.1 Document the initial Qwen 3.5 MoE compatibility profile, supported quantization assignments, hardware requirements, and known exclusions
+- [x] 9.2 Document how to add another compatible ModelOpt checkpoint without treating all NVFP4 models as architecture-compatible
+- [x] 9.3 Document fixture regeneration, installed-checkpoint qualification, and failure-diagnosis procedures
+- [x] 9.4 Update architecture support documentation and link the focused implementation to GitHub issue #228 and multimodal issue #238

--- a/openspec/changes/fix-openai-model-route-binding/.openspec.yaml
+++ b/openspec/changes/fix-openai-model-route-binding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/fix-openai-model-route-binding/design.md
+++ b/openspec/changes/fix-openai-model-route-binding/design.md
@@ -1,0 +1,66 @@
+## Context
+
+Tachyon currently exposes the local cluster through
+`https://tachyon-mesh.wsl`. The OpenAI guest owns `/v1/models` and
+`/v1/chat/completions`. Uploaded models are stored dynamically and registered in
+the shared model table, but the component host authorizes accelerator access
+only from the route's statically materialized `models` collection.
+
+The current normalizer also discards the `dynamic` flag and requires a static
+path, preventing the integrity manifest from expressing a route-scoped dynamic
+alias cleanly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a registered uploaded model usable by the OpenAI chat route.
+- Preserve route-scoped model authorization.
+- Use the dedicated HTTPS hostname `ai.tachyon-mesh.wsl` from Continue.
+- Keep the standard OpenAI `/v1` path layout.
+
+**Non-Goals:**
+
+- Grant every route access to every uploaded model.
+- Keep the OpenAI routes on `tachyon-mesh.wsl`.
+- Change authentication semantics or model execution support.
+
+## Decisions
+
+1. Preserve `IntegrityModelBinding.dynamic` during normalization. Dynamic
+   bindings may omit a static path because the runtime resolves them under the
+   managed broker model directory.
+2. Declare uploaded aliases as dynamic bindings on the
+   `/v1/chat/completions` route. This keeps authorization explicit and local to
+   the route.
+3. Keep `/v1/*` canonical under the dedicated `ai.tachyon-mesh.wsl` origin.
+   Host-based routing provides isolation without adding a nonstandard path
+   prefix or retaining duplicate endpoints.
+4. Configure Continue with `https://ai.tachyon-mesh.wsl/v1` and the local CA
+   behavior required by the workstation.
+
+## Risks / Trade-offs
+
+- [A registry entry can exist without a matching dynamic binding] → Keep the
+  binding explicit in the sealed manifest and add a regression test.
+- [The uploaded model format may still be unsupported at execution time] →
+  Surface the typed runtime error separately from authorization failures.
+- [Local clients may not trust the Home Lab CA] → Configure Continue's request
+  verification appropriately for this workstation; do not weaken the Tachyon
+  server endpoint.
+
+## Migration Plan
+
+1. Update normalization and tests.
+2. Add the dynamic binding to the deployed OpenAI chat route and reseal/reload
+   the manifest.
+3. Configure HomeLab DNS and HTTPS routing for `ai.tachyon-mesh.wsl`, removing
+   the previous `tachyon-mesh.wsl` route.
+4. Verify `/v1/models` and `/v1/chat/completions` through HTTPS.
+5. Point Continue at the HTTPS origin and remove the obsolete port-forward.
+
+Rollback restores the prior manifest and Continue configuration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-openai-model-route-binding/proposal.md
+++ b/openspec/changes/fix-openai-model-route-binding/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The OpenAI-compatible API advertises uploaded models from `GET /v1/models`, but
+`POST /v1/chat/completions` rejects the same aliases when they are absent from
+that route's sealed model bindings. This makes standards-compatible clients
+such as Continue discover a model they cannot use.
+
+## What Changes
+
+- Allow the OpenAI chat route to use broker-uploaded model aliases that are
+  registered and present under the managed dynamic-model directory.
+- Move the canonical OpenAI-compatible surface to the dedicated HTTPS origin
+  `https://ai.tachyon-mesh.wsl`, retaining the standard `/v1/models` and
+  `/v1/chat/completions` paths only on that origin.
+- Remove the OpenAI surface from `https://tachyon-mesh.wsl`.
+- Add regression coverage proving that a listed dynamic model can be selected
+  by the chat route without granting unrelated routes access to it.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `openai-compatible-faas`: A registered dynamic model listed by `/v1/models`
+  must be usable by `/v1/chat/completions` on the same deployment.
+- `ai-inference`: Dynamic model authorization must remain route-scoped while
+  supporting broker-registered aliases.
+
+## Impact
+
+- OpenAI guest route model authorization and integrity configuration.
+- Deployment manifest generation/sealing for `guest-openai`.
+- Continue's local provider endpoint.
+- HomeLab DNS and HTTPS routing for `ai.tachyon-mesh.wsl`.
+- Existing clients must update their OpenAI base URL to the new origin.

--- a/openspec/changes/fix-openai-model-route-binding/specs/ai-inference/spec.md
+++ b/openspec/changes/fix-openai-model-route-binding/specs/ai-inference/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Route-scoped dynamic model bindings
+
+The integrity manifest SHALL support dynamic model bindings whose model content
+is resolved from the managed broker model directory at runtime. A dynamic
+binding SHALL authorize only the route that declares it and SHALL NOT require a
+static model path.
+
+#### Scenario: Dynamic binding omits static path
+
+- **WHEN** integrity configuration normalization receives a model binding with
+  `dynamic: true` and an empty path
+- **THEN** normalization SHALL preserve the dynamic flag and accept the binding
+
+#### Scenario: Static binding still requires path
+
+- **WHEN** integrity configuration normalization receives a static model
+  binding with an empty path
+- **THEN** normalization SHALL reject the binding
+
+#### Scenario: Dynamic authorization remains route-scoped
+
+- **GIVEN** a dynamic alias is bound to the OpenAI chat route
+- **WHEN** another route attempts to load the same alias without declaring it
+- **THEN** the host SHALL reject that route's request as not sealed

--- a/openspec/changes/fix-openai-model-route-binding/specs/openai-compatible-faas/spec.md
+++ b/openspec/changes/fix-openai-model-route-binding/specs/openai-compatible-faas/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: User-space OpenAI-compatible FaaS
+
+The OpenAI-compatible HTTP surface SHALL be provided by a single **user-role**
+FaaS (`guest-openai`) built against the `faas-guest` WIT world. It SHALL expose
+`GET /v1/models` and `POST /v1/chat/completions`, and it SHALL NOT be a system
+FaaS injected by a compile-time feature flag. A dynamic model advertised by the
+registry SHALL be usable by the chat route when that alias is included in the
+route's sealed dynamic model bindings.
+
+#### Scenario: Model listing returns OpenAI-compatible shape
+
+- **GIVEN** the registry contains at least one available model
+- **WHEN** a client requests `GET /v1/models`
+- **THEN** `guest-openai` returns a JSON body with `object: "list"` and a `data` array
+- **AND** each item includes an `id`, `object: "model"`, and `owned_by: "tachyon-mesh"`
+
+#### Scenario: Chat completions runs real inference
+
+- **GIVEN** a sealed static or dynamic model alias the route is allowed to use
+- **WHEN** a client requests `POST /v1/chat/completions` naming that model
+- **THEN** `guest-openai` loads the model on the requested accelerator, hands
+  the structured conversation and sampling parameters to the host, and returns
+  an OpenAI-shaped `chat.completion`
+
+#### Scenario: Listed dynamic model is authorized for chat
+
+- **GIVEN** a dynamic model is registered and listed by `/v1/models`
+- **AND** the `/v1/chat/completions` route contains a sealed dynamic binding for
+  its alias
+- **WHEN** a client requests a chat completion with that alias
+- **THEN** the request SHALL pass route model authorization
+
+#### Scenario: Unknown model returns 404
+
+- **WHEN** a chat completion request names a model the host cannot load
+- **THEN** `guest-openai` responds with HTTP `404` and an OpenAI-shaped
+  `model_not_found` error body
+
+#### Scenario: Present without feature injection
+
+- **GIVEN** a node whose sealed manifest declares the `guest-openai` user routes
+- **WHEN** the topology graph is built from that manifest
+- **THEN** `guest-openai` appears as a user route regardless of whether the
+  binary was compiled with `ai-inference`

--- a/openspec/changes/fix-openai-model-route-binding/tasks.md
+++ b/openspec/changes/fix-openai-model-route-binding/tasks.md
@@ -1,0 +1,16 @@
+## 1. Integrity model binding
+
+- [x] 1.1 Preserve dynamic model bindings during integrity normalization
+- [x] 1.2 Add normalization and route-authorization regression tests
+- [x] 1.3 Resolve advertised `engine/alias` model IDs to runtime aliases
+
+## 2. Local deployment
+
+- [ ] 2.1 Add the uploaded Qwen alias as a dynamic binding on the OpenAI chat route
+- [ ] 2.2 Reseal/reload the deployed manifest and verify HTTPS chat behavior
+- [x] 2.3 Route `ai.tachyon-mesh.wsl` through HomeLab and remove the old hostname route
+
+## 3. Continue integration
+
+- [x] 3.1 Point Continue at `https://ai.tachyon-mesh.wsl/v1`
+- [x] 3.2 Remove the obsolete workstation port-forward and verify model discovery

--- a/scripts/export_qwen35_moe_fixtures.py
+++ b/scripts/export_qwen35_moe_fixtures.py
@@ -1,0 +1,83 @@
+"""Export deterministic Qwen 3.5 MoE fixtures from a local HF model.
+
+The script never downloads a model. It records configuration, selected
+intermediate outputs, cache state shapes, and logits for parity tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prompt", default="Tachyon")
+    args = parser.parse_args()
+    if not args.model.is_dir():
+        raise SystemExit(f"local model directory does not exist: {args.model}")
+
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model, local_files_only=True, trust_remote_code=False
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        local_files_only=True,
+        trust_remote_code=False,
+        torch_dtype=torch.float32,
+        device_map="cpu",
+    ).eval()
+    encoded = tokenizer(args.prompt, return_tensors="pt")
+    captures: dict[str, object] = {}
+    hooks = []
+
+    def capture(name: str):
+        def hook(_module, _inputs, output):
+            tensor = output[0] if isinstance(output, tuple) else output
+            if isinstance(tensor, torch.Tensor):
+                flat = tensor.detach().float().cpu().flatten()
+                captures[name] = {
+                    "shape": list(tensor.shape),
+                    "values": flat[: min(flat.numel(), 4096)].tolist(),
+                }
+
+        return hook
+
+    text_model = getattr(getattr(model, "model", model), "language_model", None)
+    text_model = text_model or getattr(model, "model", model)
+    for index, layer in enumerate(text_model.layers):
+        hooks.append(layer.register_forward_hook(capture(f"layers.{index}")))
+
+    with torch.inference_mode():
+        output = model(**encoded, use_cache=True)
+    for hook in hooks:
+        hook.remove()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    config = json.loads((args.model / "config.json").read_text(encoding="utf-8"))
+    fixture = {
+        "prompt": args.prompt,
+        "input_ids": encoded["input_ids"].tolist(),
+        "config": config,
+        "captures": captures,
+        "logits": output.logits.detach().float().cpu()[0, -1, :4096].tolist(),
+        "cache_shapes": [
+            [list(t.shape) for t in layer]
+            for layer in output.past_key_values
+            if isinstance(layer, (tuple, list))
+        ],
+    }
+    (args.output / "qwen35_moe_golden.json").write_text(
+        json.dumps(fixture, indent=2), encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- add a fail-closed Qwen 3.5 MoE architecture registry and runtime
- execute hybrid full-attention and gated-delta layers with sparse routed/shared experts
- add packed FP8/NVFP4 operators, bounded working-set paging, streaming generation, fixtures and probes
- preserve dynamic OpenAI model bindings and resolve public model IDs to registry aliases

## Why

The installed NVIDIA Qwen checkpoint was detected as ModelOpt/NVFP4 but had no architecture runtime, so OpenAI chat requests could not execute real inference.

## Validation

- cargo check -p core-host --features ai-inference
- RUSTFLAGS=-D dead_code cargo check -p core-host --features ai-inference
- cargo test -p core-host --features ai-inference ai_inference:: -- --nocapture (139 passed)
- cargo build -p guest-openai --target wasm32-wasip2 --release
- openspec validate add-qwen35-moe-nvfp4-runtime
- openspec validate fix-openai-model-route-binding