### PR TITLE
[codex] Preserve static OpenAI model aliases

### DIFF
--- a/examples/guest-openai/src/lib.rs
+++ b/examples/guest-openai/src/lib.rs
@@ -229,12 +229,16 @@ fn handle_chat_completions(body: &[u8]) -> Result<(u16, Vec<u8>), String> {
     }
 
     let models = list_models()?;
-    let Some(alias) = resolve_model_alias(&request.model, &models) else {
-        return Ok(openai_error_payload(
-            404,
-            format!("model `{}` is unavailable", request.model),
-            "model_not_found",
-        ));
+    let alias = match resolve_model_alias(&request.model, &models) {
+        Some(alias) => alias,
+        None if !request.model.contains('/') => request.model.as_str(),
+        None => {
+            return Ok(openai_error_payload(
+                404,
+                format!("model `{}` is unavailable", request.model),
+                "model_not_found",
+            ));
+        }
     };
 
     let model_id = match bindings::tachyon::accelerator::cpu::load_model(alias) {


### PR DESCRIPTION
## What changed

Allow plain OpenAI model IDs to fall back to static route bindings when they are absent from the dynamic model registry. Engine-qualified IDs still require a registry match.

## Why

The Qwen model-ID resolver unintentionally rejected existing static aliases such as the llama3 binding used by the SSE integration path.

## Validation

- cargo test -p guest-openai
- cargo build -p guest-openai --target wasm32-wasip2 --release
- TACHYON_REQUIRE_GUEST_OPENAI=1 cargo test -p core-host --features ai-inference --bin core-host streaming_guest_openai -- --nocapture