### PR TITLE
[codex] Document protected main workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Branch and issue discipline
+
+`main` is a protected branch. Do not push implementation work directly to it.
+Every change must land through a pull request targeting `main`.
+
+Before a pull request can merge, it must be up to date with `main` and pass the
+required GitHub Actions status checks:
+
+- `quality`
+- `cuda-quality`
+- `security-audit`
+- `build-guests`
+
+Close issues only when the fix has landed on `main`. Prefer `Fixes #N` or
+`Closes #N` in the pull request body so GitHub closes the issue automatically
+when the PR is merged. Do not close an issue while its fix exists only on an
+unmerged branch.
+
+For large batches, especially changes touching more than a small focused set of
+files, request review before merge. If the work is solo-maintained, leave a
+short self-review note in the PR covering the risk areas and validation run.
+
+## Local validation
+
+Run the fast quality gate before opening or updating a PR when the change
+touches Rust code:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --features core-host/ai-inference -- -D warnings -D clippy::unwrap_used
+```
+
+For feature-gated code, also run the smallest relevant `cargo check` or test
+command matching the feature you changed.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ scripts/build-guest-artifacts.sh examples/guest-example
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please refer to `CONTRIBUTING.md` (coming soon) and use the `openspec/` directory format for any architectural change proposals.
+Contributions are welcome! Please refer to `CONTRIBUTING.md` and use the `openspec/` directory format for any architectural change proposals.
 
 ---
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,13 +1,17 @@
 schema: spec-driven
 
-# Project context (optional)
-# This is shown to AI when creating artifacts.
-# Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  Contributions must land through pull requests targeting `main`; direct
+  implementation pushes to `main` are not allowed. PRs must be up to date with
+  `main` and pass the required checks `quality`, `cuda-quality`,
+  `security-audit`, and `build-guests` before merge.
+
+  Issues are closed only after their fix has landed on `main`. Use `Fixes #N`
+  or `Closes #N` in PR bodies so GitHub closes issues on merge, and do not mark
+  an issue resolved while its commits live only on an unmerged branch.
+
+  For Rust changes, the canonical local quality check is:
+  `cargo clippy --workspace --all-targets --features core-host/ai-inference -- -D warnings -D clippy::unwrap_used`.
 
 # Per-artifact rules (optional)
 # Add custom rules for specific artifacts.


### PR DESCRIPTION
## What changed
- Enabled branch protection on `main` through GitHub branch protection settings.
- Added `CONTRIBUTING.md` with the protected-branch, required-checks, issue-closure, review, and local-validation rules.
- Added the same process rules to `openspec/config.yaml` so future OpenSpec work inherits them.
- Updated the README to point to the new contributing guide.

## Branch protection applied
`main` now requires pull requests, an up-to-date branch before merge, and the required checks `quality`, `cuda-quality`, `security-audit`, and `build-guests`. Admin enforcement is enabled, force pushes are disabled, and branch deletion is disabled.

## Validation
- `git diff --check -- README.md CONTRIBUTING.md openspec/config.yaml`
- `openspec validate --all --strict --no-interactive` (138 passed, 0 failed)
- Verified GitHub branch protection via `gh api repos/astorise/Tachyon-Mesh/branches/main/protection`

Fixes #300