### PR TITLE
Pin Candle fork by Renovate-trackable tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-flashinfer-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "cudaforge",
 ]
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "candle-core",
  "half",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?rev=60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1#60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -57,14 +57,14 @@ arc-swap = "1.7"
 axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
-candle-core = { git = "https://github.com/astorise/candle", rev = "60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da", version = "0.11.0", optional = true }
-candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", rev = "60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da", version = "0.11.0", optional = true, default-features = false }
-candle-nn = { git = "https://github.com/astorise/candle", rev = "60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da", version = "0.11.0", optional = true }
-candle-onnx = { git = "https://github.com/astorise/candle", rev = "60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da", version = "0.11.0", optional = true }
+candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-1", version = "0.11.0", optional = true }
+candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-1", version = "0.11.0", optional = true, default-features = false }
+candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-1", version = "0.11.0", optional = true }
+candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-1", version = "0.11.0", optional = true }
 # Standard transformer architectures (Llama family) for running real, uploaded
 # checkpoints. Weights are mmapped from the model directory at runtime — never
 # compiled into the Tachyon artifact.
-candle-transformers = { git = "https://github.com/astorise/candle", rev = "60b4ad1c91dbb95ddf23fcdbdd1f0e9cecb0a9da", version = "0.11.0", optional = true, default-features = false }
+candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-1", version = "0.11.0", optional = true, default-features = false }
 parallel-topology = { path = "../crates/parallel-topology", optional = true }
 # Same cudarc version `candle-core`'s CUDA backend already vendors (see
 # Cargo.lock), so this reuses one NCCL binding instead of introducing a

--- a/docs/ai-inference-candle-llm-runtime.md
+++ b/docs/ai-inference-candle-llm-runtime.md
@@ -76,7 +76,12 @@ unsupported-architecture error.
 
 ## PagedAttention Status
 
-The pinned `astorise/candle` fork includes Candle's paged flash-attn API
+The pinned `astorise/candle` fork is consumed through a Tachyon release tag
+(`tachyon-v0.11.0-1` at the time of writing), not a raw commit rev, so Renovate
+can track the git ref. Each fork refresh should rebase the fork on the selected
+upstream Candle commit, run the Candle/Tachyon AI inference checks, publish a new
+`tachyon-v<upstream-version>-<N>` tag, and update `core-host/Cargo.toml` plus
+`Cargo.lock` together. The fork includes Candle's paged flash-attn API
 (`flash_attn_varlen_paged_windowed`), but Tachyon does not yet own the required
 runtime state for it: a CUDA KV block pool, per-sequence block tables, and
 block-granular allocation/free during continuous batching.

--- a/openspec/specs/ai-inference/spec.md
+++ b/openspec/specs/ai-inference/spec.md
@@ -101,15 +101,22 @@ The repository SHALL build the `guest-ai` artifact in CI and validate that the o
 
 ### Requirement: Downstream Candle quantization kernels MUST be consumed through the pinned fork
 The AI inference build SHALL consume Candle from the pinned `astorise/candle`
-revision that includes the downstream GPTQ/Marlin, AWQ, and block-wise FP8
+release tag that includes the downstream GPTQ/Marlin, AWQ, and block-wise FP8
 weight-quantization kernel work proposed upstream in `huggingface/candle#3650`.
 This integration SHALL be represented as dependency selection in Tachyon rather
-than by duplicating those Candle kernels in `core-host`.
+than by duplicating those Candle kernels in `core-host`. The fork ref SHALL use
+a Renovate-trackable named ref such as `tag = "tachyon-v<upstream-version>-<N>"`
+rather than a raw git `rev` pin.
 
 #### Scenario: AI inference resolves the forked Candle crates
 - **WHEN** the optional AI inference dependency graph is resolved
 - **THEN** `candle-core`, `candle-nn`, `candle-onnx`, and `candle-transformers` come from `https://github.com/astorise/candle`
-- **AND** Cargo.lock pins them to a single fork revision containing the downstream quantization work
+- **AND** Cargo.lock pins them to a single fork tag containing the downstream quantization work
+
+#### Scenario: Renovate can monitor the forked Candle ref
+- **WHEN** Renovate scans `core-host/Cargo.toml`
+- **THEN** the Candle git dependencies use a named tag ref instead of a raw commit rev
+- **AND** the dependency dashboard does not report `Could not determine new digest for update` for the `astorise/candle` git dependency
 
 #### Scenario: Default builds do not link Candle quantization code
 - **WHEN** `core-host` is built without `--features ai-inference`
@@ -662,8 +669,8 @@ When a model deployment sets `hardware_strategy.paged_attention: true`, the runt
 - **AND** sequence admission and eviction operate at block granularity rather than reallocating a contiguous KV cache per request
 
 ### Requirement: CUDA Graph and FlashInfer decode acceleration MUST be explicit and fail-closed
-The AI inference build SHALL consume the pinned `astorise/candle` fork revision
-that exposes `candle_core::CudaGraph` and the optional
+The AI inference build SHALL consume the pinned `astorise/candle` fork tag that
+exposes `candle_core::CudaGraph` and the optional
 `candle-flashinfer-kernels` crate for the downstream work proposed in
 `huggingface/candle#3651`. Model deployments MAY declare
 `hardware_strategy.cuda_graph_decode` and


### PR DESCRIPTION
## Summary
- Pin the `astorise/candle` dependencies by the Renovate-trackable tag `tachyon-v0.11.0-1` instead of a raw git `rev`.
- Update `Cargo.lock` so all Candle crates resolve through the same tag and commit.
- Document the fork refresh/tagging cycle in the AI runtime documentation and OpenSpec active `ai-inference` spec.

Closes #304

## Validation
- `cargo metadata --locked --format-version 1 --no-deps` confirms Candle dependencies resolve from `git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-1`.
- `openspec validate --specs --strict` passed: 138 specs.
- `cargo build --locked -p core-host --features ai-inference` passed.
- `cargo test --locked -p core-host --features ai-inference ai_inference::` passed: 169 tests.

## Note
A full `cargo test --locked -p core-host --features ai-inference` was also attempted. It compiled and ran, but failed on existing integration tests that require prebuilt guest Wasm artifacts such as `guest_example.wasm`, `guest_tcp_echo.wasm`, `guest_ai.wasm`, `guest_volume.wasm`, `gossip.wasm`, and `system_faas_gc.wasm` in `target/wasm32-*` or `guest-modules/`. The failures are outside the Candle dependency pinning path.