### PR TITLE
[codex] Wire websocket local mesh dispatch

### DIFF
--- a/core-host/src/host_core/component_hosts.rs
+++ b/core-host/src/host_core/component_hosts.rs
@@ -2884,6 +2884,32 @@ impl control_plane_component_bindings::tachyon::mesh::outbound_http::Host for Co
     }
 }
 
+#[cfg(feature = "websockets")]
+impl websocket_component_bindings::tachyon::mesh::outbound_http::Host for ComponentHostState {
+    fn send_request(
+        &mut self,
+        method: String,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> std::result::Result<
+        websocket_component_bindings::tachyon::mesh::outbound_http::Response,
+        String,
+    > {
+        let response =
+            <Self as background_component_bindings::tachyon::mesh::outbound_http::Host>::send_request(
+                self, method, url, headers, body,
+            )?;
+        Ok(
+            websocket_component_bindings::tachyon::mesh::outbound_http::Response {
+                status: response.status,
+                headers: response.headers,
+                body: response.body,
+            },
+        )
+    }
+}
+
 pub(crate) fn rewrite_outbound_http_url(url: &str, runtime_config: &IntegrityConfig) -> String {
     if let Some(path) = url.strip_prefix("http://mesh") {
         let host = runtime_config

--- a/core-host/src/host_core/guest_runtime.rs
+++ b/core-host/src/host_core/guest_runtime.rs
@@ -897,6 +897,19 @@ pub(crate) fn execute_websocket_component_guest(
                 "failed to add WebSocket host functions to component linker",
             )
         })?;
+        // Authorization-gated: URL validated against scopes.http per call.
+        if shape.grants(ScopeCategory::Http) {
+            websocket_component_bindings::tachyon::mesh::outbound_http::add_to_linker::<
+                ComponentHostState,
+                ComponentHostState,
+            >(&mut l, |s: &mut ComponentHostState| s)
+            .map_err(|e| {
+                guest_execution_error(
+                    e,
+                    "failed to add outbound HTTP functions to WebSocket component linker",
+                )
+            })?;
+        }
         Ok(l)
     };
     let linker: Arc<ComponentLinker<ComponentHostState>> = match &execution.linker_cache {
@@ -916,7 +929,7 @@ pub(crate) fn execute_websocket_component_guest(
             Arc::clone(&execution.storage_broker),
             Arc::clone(&execution.concurrency_limits),
             execution.propagated_headers.clone(),
-            None,
+            execution.local_mesh_dispatch.clone(),
             &[],
         )?,
     );

--- a/core-host/src/host_core/tests/routing_aliases.rs
+++ b/core-host/src/host_core/tests/routing_aliases.rs
@@ -67,7 +67,10 @@ async fn websocket_route_upgrades_and_echoes_frames() {
         .await
         .expect("WebSocket server should respond")
         .expect("WebSocket frame should be valid");
-    assert!(matches!(text_frame, Message::Text(text) if text == "hello"));
+    assert!(
+        matches!(&text_frame, Message::Text(text) if *text == "hello"),
+        "expected text echo, got: {text_frame:?}"
+    );
 
     client
         .send(Message::Binary(vec![1_u8, 2, 3].into()))
@@ -78,7 +81,10 @@ async fn websocket_route_upgrades_and_echoes_frames() {
         .await
         .expect("WebSocket server should respond to binary frame")
         .expect("WebSocket frame should be valid");
-    assert!(matches!(binary_frame, Message::Binary(bytes) if bytes.as_ref() == [1_u8, 2, 3]));
+    assert!(
+        matches!(&binary_frame, Message::Binary(bytes) if bytes.as_ref() == [1_u8, 2, 3]),
+        "expected binary echo, got: {binary_frame:?}"
+    );
 
     client
         .close(None)
@@ -635,4 +641,141 @@ async fn outbound_http_import_attempts_sealed_local_route_in_process() {
             );
         }
     }
+}
+
+#[cfg(feature = "websockets")]
+#[tokio::test(flavor = "multi_thread")]
+async fn websocket_outbound_http_import_attempts_sealed_local_route_in_process() {
+    let websocket_route =
+        targeted_route("/ws/local", vec![websocket_target("guest-websocket-echo")]);
+    let mut config = IntegrityConfig {
+        routes: vec![IntegrityRoute::user(DEFAULT_ROUTE), websocket_route],
+        ..IntegrityConfig::default_sealed()
+    };
+    config.host_address = "127.0.0.1:9".to_owned();
+    let config = validate_integrity_config(config).expect("config should validate");
+    let state = build_test_state(config.clone(), telemetry::init_test_telemetry());
+    let runtime = state.runtime.load_full();
+    let caller_route = config
+        .sealed_route("/ws/local")
+        .expect("websocket route should remain sealed");
+    let mut host = ComponentHostState::new(
+        caller_route,
+        config.clone(),
+        runtime.config.guest_memory_limit_bytes,
+        state.telemetry.clone(),
+        SecretAccess::default(),
+        HeaderMap::new(),
+        Arc::clone(&state.host_identity),
+        Arc::clone(&state.storage_broker),
+        Arc::clone(&runtime.concurrency_limits),
+        Vec::new(),
+        Some(LocalMeshDispatchContext {
+            state: state.clone(),
+            runtime,
+            handle: tokio::runtime::Handle::current(),
+        }),
+        &[],
+    )
+    .expect("component host state should build");
+
+    let result = tokio::task::spawn_blocking(move || {
+        <ComponentHostState as websocket_component_bindings::tachyon::mesh::outbound_http::Host>::send_request(
+            &mut host,
+            "GET".to_owned(),
+            "http://mesh/api/guest-example".to_owned(),
+            Vec::new(),
+            Vec::new(),
+        )
+    })
+    .await
+    .expect("websocket outbound HTTP import should run on a blocking worker");
+
+    match result {
+        Ok(response) => {
+            assert_eq!(response.status, StatusCode::OK.as_u16());
+            let body = String::from_utf8_lossy(&response.body);
+            assert!(
+                body.trim()
+                    .starts_with("FaaS received an empty payload | env: missing | secret:"),
+                "expected local guest response body, got: {body}"
+            );
+        }
+        Err(error) => {
+            assert!(
+                error.contains("guest artifact not found"),
+                "expected local guest loading failure, got: {error}"
+            );
+            assert!(
+                !error.contains("failed to send") && !error.contains("connection refused"),
+                "websocket sealed outbound HTTP should not fall through to transport: {error}"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "websockets")]
+#[tokio::test(flavor = "multi_thread")]
+async fn websocket_outbound_http_import_yields_to_transport_when_route_is_saturated() {
+    let mut local_route = IntegrityRoute::user(DEFAULT_ROUTE);
+    local_route.max_concurrency = 1;
+    let websocket_route =
+        targeted_route("/ws/local", vec![websocket_target("guest-websocket-echo")]);
+    let mut config = IntegrityConfig {
+        routes: vec![local_route, websocket_route],
+        ..IntegrityConfig::default_sealed()
+    };
+    config.host_address = "127.0.0.1:9".to_owned();
+    let config = validate_integrity_config(config).expect("config should validate");
+    let state = build_test_state(config.clone(), telemetry::init_test_telemetry());
+    let runtime = state.runtime.load_full();
+    let semaphore = runtime
+        .concurrency_limits
+        .get(DEFAULT_ROUTE)
+        .expect("default route should have a concurrency limiter");
+    let _permit = semaphore
+        .semaphore
+        .clone()
+        .try_acquire_owned()
+        .expect("test should acquire the only local permit");
+    let caller_route = config
+        .sealed_route("/ws/local")
+        .expect("websocket route should remain sealed");
+    let mut host = ComponentHostState::new(
+        caller_route,
+        config.clone(),
+        runtime.config.guest_memory_limit_bytes,
+        state.telemetry.clone(),
+        SecretAccess::default(),
+        HeaderMap::new(),
+        Arc::clone(&state.host_identity),
+        Arc::clone(&state.storage_broker),
+        Arc::clone(&runtime.concurrency_limits),
+        Vec::new(),
+        Some(LocalMeshDispatchContext {
+            state: state.clone(),
+            runtime,
+            handle: tokio::runtime::Handle::current(),
+        }),
+        &[],
+    )
+    .expect("component host state should build");
+
+    let result = tokio::task::spawn_blocking(move || {
+        <ComponentHostState as websocket_component_bindings::tachyon::mesh::outbound_http::Host>::send_request(
+            &mut host,
+            "GET".to_owned(),
+            "http://mesh/api/guest-example".to_owned(),
+            Vec::new(),
+            Vec::new(),
+        )
+    })
+    .await
+    .expect("websocket outbound HTTP import should run on a blocking worker")
+    .expect_err("saturated local route should fall back to transport");
+
+    assert!(
+        result.contains("failed to send") || result.contains("connection refused"),
+        "expected transport fallback failure, got: {result}"
+    );
 }

--- a/core-host/src/network/mod.rs
+++ b/core-host/src/network/mod.rs
@@ -713,6 +713,11 @@ pub(crate) async fn handle_websocket_connection(
     socket: WebSocket,
 ) -> Result<()> {
     let runtime = state.runtime.load_full();
+    let local_mesh_dispatch = LocalMeshDispatchContext {
+        state: state.clone(),
+        runtime: Arc::clone(&runtime),
+        handle: tokio::runtime::Handle::current(),
+    };
     let volume_leases = state
         .volume_manager
         .acquire_route_volumes(&route, Arc::clone(&state.storage_broker))
@@ -815,6 +820,7 @@ pub(crate) async fn handle_websocket_connection(
         .component_instance_pre_cache(Some(component_instance_pre_cache))
         .legacy_instance_pre_cache(Some(legacy_instance_pre_cache))
         .linker_cache(Some(linker_cache))
+        .local_mesh_dispatch(Some(local_mesh_dispatch))
         .build();
         let _ = result_tx.send(execute_websocket_guest(
             &engine,

--- a/openspec/specs/http-routing/spec.md
+++ b/openspec/specs/http-routing/spec.md
@@ -223,6 +223,12 @@ rewrites the target.
 - **AND** the original method, headers, body, query string, cohort context, route policies, and decremented hop limit are preserved
 - **AND** the host uses UDS/TCP only when the local route is saturated, unavailable, or under critical memory pressure
 
+#### Scenario: WebSocket guest outbound HTTP targets a local sealed route
+- **WHEN** a WebSocket component guest calls `tachyon:mesh/outbound-http.send-request` with an internal mesh URL
+- **AND** the URL resolves to a sealed route in the same host process
+- **THEN** the host dispatches the target route in-process using the WebSocket execution context
+- **AND** the host uses UDS/TCP only when the local route is saturated, unavailable, or under critical memory pressure
+
 #### Scenario: External resource alias rewrites to a sealed HTTPS endpoint
 - **WHEN** a guest requests `http://mesh/payment-gateway/charges?expand=1`
 - **AND** `payment-gateway` is sealed as an external resource alias targeting

--- a/openspec/specs/websockets/spec.md
+++ b/openspec/specs/websockets/spec.md
@@ -11,6 +11,14 @@ The Tachyon WIT package SHALL define a WebSocket connection resource with typed 
 - **WHEN** a WebSocket-capable guest is built against the Tachyon WIT package
 - **THEN** it can export `on-connect` and use a connection resource to send and receive typed frames
 
+### Requirement: WebSocket guests can call scoped outbound HTTP
+The `websocket-faas-guest` WIT world SHALL expose `tachyon:mesh/outbound-http` so WebSocket guests can call sealed mesh routes through the same scoped outbound HTTP host import as other component guests.
+
+#### Scenario: WebSocket guest calls outbound HTTP
+- **WHEN** a WebSocket-capable guest is built against the Tachyon WIT package
+- **THEN** it can import `outbound-http.send-request`
+- **AND** the host validates the target URL against the deployment's HTTP scopes before dispatch
+
 ### Requirement: Routes explicitly opt into WebSocket upgrades
 The integrity manifest SHALL allow a route or target to declare that it expects a WebSocket upgrade instead of standard HTTP-only request handling.
 

--- a/wit/tachyon.wit
+++ b/wit/tachyon.wit
@@ -339,6 +339,7 @@ world udp-faas-guest {
 world websocket-faas-guest {
     import secrets-vault;
     import websocket;
+    import outbound-http;
     use websocket.{connection};
     export on-connect: func(connection: borrow<connection>);
 }


### PR DESCRIPTION
## Summary

Fixes #306.

- Wire `LocalMeshDispatchContext` into the WebSocket guest execution path so WebSocket guests can use in-process local mesh dispatch.
- Expose and link `tachyon:mesh/outbound-http` for the `websocket-faas-guest` world, reusing the existing scoped outbound HTTP host implementation.
- Add WebSocket-specific regression coverage for local in-process dispatch and saturated-route fallback, and update active OpenSpec docs for the behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p core-host --features websockets`
- `cargo test -p core-host --features websockets websocket_outbound_http_import -- --nocapture`
- `cargo test -p core-host --features websockets websocket_route_upgrades_and_echoes_frames -- --nocapture`
- `cargo build -p core-host --features websockets`
- `cargo build -p guest-websocket-echo --target wasm32-wasip2`
- `openspec validate --all`