### PR TITLE
fix(mesh): overflow saturated in-process dispatch to a real peer, not…

### DIFF
--- a/core-host/src/host_core/app_runtime.rs
+++ b/core-host/src/host_core/app_runtime.rs
@@ -2684,16 +2684,6 @@ pub(crate) async fn try_dispatch_local_mesh_request(
             MeshDispatchReason::Remote,
         ));
     }
-    if state.memory_governor.pressure() == memory_governor::MemoryPressure::Critical {
-        record_mesh_dispatch(
-            MeshDispatchMode::InProcess,
-            MeshDispatchReason::Pressure,
-            started_at.elapsed(),
-        );
-        return Ok(LocalMeshDispatchAttempt::Fallback(
-            MeshDispatchReason::Pressure,
-        ));
-    }
 
     let url = reqwest::Url::parse(resolved_url)
         .map_err(|error| format!("internal mesh target `{resolved_url}` is invalid: {error}"))?;
@@ -2736,15 +2726,42 @@ pub(crate) async fn try_dispatch_local_mesh_request(
             MeshDispatchReason::Remote,
         ));
     };
-    if semaphore.semaphore.available_permits() == 0 {
-        record_mesh_dispatch(
-            MeshDispatchMode::InProcess,
-            MeshDispatchReason::Saturated,
-            started_at.elapsed(),
-        );
-        return Ok(LocalMeshDispatchAttempt::Fallback(
-            MeshDispatchReason::Saturated,
-        ));
+    let saturation_reason =
+        if state.memory_governor.pressure() == memory_governor::MemoryPressure::Critical {
+            Some(MeshDispatchReason::Pressure)
+        } else if semaphore.semaphore.available_permits() == 0 {
+            Some(MeshDispatchReason::Saturated)
+        } else {
+            None
+        };
+
+    if let Some(reason) = saturation_reason {
+        // `network = overflow`: a saturated local route with `allow_overflow`
+        // routes the hop to the least-pressured eligible mesh peer (the same
+        // `control_plane_override_destination` lookup and mTLS transport the
+        // `RoutePermitError::TimedOut` branch of
+        // `execute_route_request_with_acquired_permit` already uses) instead
+        // of looping back into this same node's UDS/TCP fast path. The local
+        // queue remains the last resort when no peer is eligible.
+        if route.allow_overflow {
+            if let Some(response) = try_peer_overflow_dispatch(
+                state,
+                &route,
+                selected_target.required_capability_mask,
+                headers,
+                method,
+                &body,
+                hop_limit,
+                reason,
+                started_at,
+            )
+            .await?
+            {
+                return Ok(LocalMeshDispatchAttempt::Handled(response));
+            }
+        }
+        record_mesh_dispatch(MeshDispatchMode::InProcess, reason, started_at.elapsed());
+        return Ok(LocalMeshDispatchAttempt::Fallback(reason));
     }
 
     let uri = append_query(&normalized_path, url.query())
@@ -2777,6 +2794,52 @@ pub(crate) async fn try_dispatch_local_mesh_request(
         started_at.elapsed(),
     );
     Ok(LocalMeshDispatchAttempt::Handled(result.response))
+}
+
+/// Resolves an eligible mesh peer for a saturated/pressured local route and
+/// forwards the request to it, mirroring the overflow branch that
+/// `execute_route_request_with_acquired_permit` already runs on
+/// `RoutePermitError::TimedOut`. Returns `Ok(None)` when no eligible peer is
+/// known, so the caller falls through to the local UDS/TCP queue.
+#[allow(clippy::too_many_arguments)]
+async fn try_peer_overflow_dispatch(
+    state: &AppState,
+    route: &IntegrityRoute,
+    required_capability_mask: u64,
+    headers: &HeaderMap,
+    method: &Method,
+    body: &Bytes,
+    hop_limit: HopLimit,
+    reason: MeshDispatchReason,
+    started_at: Instant,
+) -> std::result::Result<Option<GuestHttpResponse>, String> {
+    let requested_model = requested_model_alias(route, headers, body);
+    let Some(destination) = control_plane_override_destination(
+        state.route_overrides.as_ref(),
+        &state.peer_capabilities,
+        &route.path,
+        headers,
+        required_capability_mask,
+        requested_model.as_deref(),
+    ) else {
+        return Ok(None);
+    };
+
+    let response = forward_request_to_override_as_guest_response(
+        &state.http_client,
+        &destination,
+        headers,
+        method,
+        body,
+        hop_limit,
+    )
+    .await
+    .map_err(|(status, message)| {
+        format!("mesh peer overflow forward to `{destination}` failed with {status}: {message}")
+    })?;
+
+    record_mesh_dispatch(MeshDispatchMode::Peer, reason, started_at.elapsed());
+    Ok(Some(response))
 }
 
 pub(crate) enum LocalMeshDispatchAttempt {

--- a/core-host/src/host_core/mesh_dispatch_metrics.rs
+++ b/core-host/src/host_core/mesh_dispatch_metrics.rs
@@ -16,6 +16,7 @@ pub(crate) enum MeshDispatchMode {
     InProcess,
     Uds,
     Tcp,
+    Peer,
 }
 
 impl MeshDispatchMode {
@@ -24,6 +25,7 @@ impl MeshDispatchMode {
             Self::InProcess => "in_process",
             Self::Uds => "uds",
             Self::Tcp => "tcp",
+            Self::Peer => "peer",
         }
     }
 }

--- a/core-host/src/host_core/tests/routing_aliases.rs
+++ b/core-host/src/host_core/tests/routing_aliases.rs
@@ -588,6 +588,172 @@ async fn local_mesh_dispatch_yields_to_transport_when_route_is_saturated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn local_mesh_dispatch_overflows_to_peer_when_saturated_and_overflow_allowed() {
+    use axum::{body::Bytes as AxumBytes, routing::any, Router};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct PeerCapture {
+        hop_limits: Vec<String>,
+    }
+
+    let peer_capture = Arc::new(Mutex::new(PeerCapture::default()));
+    let capture_for_handler = Arc::clone(&peer_capture);
+    let peer_app = Router::new().route(
+        DEFAULT_ROUTE,
+        any(move |headers: HeaderMap, _body: AxumBytes| {
+            let capture = Arc::clone(&capture_for_handler);
+            async move {
+                capture
+                    .lock()
+                    .expect("peer capture should not be poisoned")
+                    .hop_limits
+                    .push(
+                        headers
+                            .get(HOP_LIMIT_HEADER)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned(),
+                    );
+                (StatusCode::OK, "peer-ok")
+            }
+        }),
+    );
+    let peer_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("peer listener should bind");
+    let peer_address = peer_listener
+        .local_addr()
+        .expect("peer listener should expose an address");
+    let peer_server = tokio::spawn(async move {
+        axum::serve(peer_listener, peer_app)
+            .await
+            .expect("peer app should stay up");
+    });
+
+    let mut route = IntegrityRoute::user(DEFAULT_ROUTE);
+    route.max_concurrency = 1;
+    route.allow_overflow = true;
+    let config = validate_integrity_config(IntegrityConfig {
+        routes: vec![route],
+        ..IntegrityConfig::default_sealed()
+    })
+    .expect("config should validate");
+    let state = build_test_state(config, telemetry::init_test_telemetry());
+    let runtime = state.runtime.load_full();
+    let semaphore = runtime
+        .concurrency_limits
+        .get(DEFAULT_ROUTE)
+        .expect("default route should have a concurrency limiter");
+    let _permit = semaphore
+        .semaphore
+        .clone()
+        .try_acquire_owned()
+        .expect("test should acquire the only local permit");
+
+    // Simulates `system-faas-mesh-overlay` having already published a
+    // healthier peer for this route via `routing_control::update-target`.
+    update_control_plane_route_override(
+        state.route_overrides.as_ref(),
+        &state.peer_capabilities,
+        DEFAULT_ROUTE,
+        &format!("http://{peer_address}{DEFAULT_ROUTE}"),
+    )
+    .expect("route override should install");
+
+    let before = mesh_dispatch_total_for(MeshDispatchMode::Peer, MeshDispatchReason::Saturated);
+    let response = try_dispatch_local_mesh_request(
+        &state,
+        &runtime,
+        "http://127.0.0.1:9/api/guest-example",
+        &Method::GET,
+        &HeaderMap::new(),
+        Bytes::new(),
+        Vec::new(),
+        HopLimit(DEFAULT_HOP_LIMIT),
+    )
+    .await
+    .expect("saturated route with an eligible peer should overflow, not error");
+
+    let LocalMeshDispatchAttempt::Handled(handled) = response else {
+        panic!("expected the saturated route to be handled via peer overflow");
+    };
+    assert_eq!(handled.status, StatusCode::OK);
+    assert_eq!(&handled.body[..], b"peer-ok");
+    assert_eq!(
+        mesh_dispatch_total_for(MeshDispatchMode::Peer, MeshDispatchReason::Saturated),
+        before + 1
+    );
+
+    let captured = peer_capture
+        .lock()
+        .expect("peer capture should not be poisoned");
+    assert_eq!(
+        captured.hop_limits,
+        vec![HopLimit(DEFAULT_HOP_LIMIT).decremented().to_string()]
+    );
+    drop(captured);
+
+    peer_server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn local_mesh_dispatch_stays_local_when_no_peer_is_eligible_despite_allow_overflow() {
+    let mut route = IntegrityRoute::user(DEFAULT_ROUTE);
+    route.max_concurrency = 1;
+    route.allow_overflow = true;
+    let config = validate_integrity_config(IntegrityConfig {
+        routes: vec![route],
+        ..IntegrityConfig::default_sealed()
+    })
+    .expect("config should validate");
+    let state = build_test_state(config, telemetry::init_test_telemetry());
+    let runtime = state.runtime.load_full();
+    let semaphore = runtime
+        .concurrency_limits
+        .get(DEFAULT_ROUTE)
+        .expect("default route should have a concurrency limiter");
+    let _permit = semaphore
+        .semaphore
+        .clone()
+        .try_acquire_owned()
+        .expect("test should acquire the only local permit");
+
+    // No `route_overrides` entry was ever published for this route, so no
+    // peer is eligible: the local queue remains the last resort even though
+    // `allow_overflow` is set.
+    let before =
+        mesh_dispatch_total_for(MeshDispatchMode::InProcess, MeshDispatchReason::Saturated);
+    let peer_before =
+        mesh_dispatch_total_for(MeshDispatchMode::Peer, MeshDispatchReason::Saturated);
+    let response = try_dispatch_local_mesh_request(
+        &state,
+        &runtime,
+        "http://127.0.0.1:9/api/guest-example",
+        &Method::GET,
+        &HeaderMap::new(),
+        Bytes::new(),
+        Vec::new(),
+        HopLimit(DEFAULT_HOP_LIMIT),
+    )
+    .await
+    .expect("saturated route without an eligible peer should fall back to the local queue");
+
+    assert!(matches!(
+        response,
+        LocalMeshDispatchAttempt::Fallback(MeshDispatchReason::Saturated)
+    ));
+    assert_eq!(
+        mesh_dispatch_total_for(MeshDispatchMode::InProcess, MeshDispatchReason::Saturated),
+        before + 1
+    );
+    assert_eq!(
+        mesh_dispatch_total_for(MeshDispatchMode::Peer, MeshDispatchReason::Saturated),
+        peer_before
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn local_mesh_dispatch_honors_bench_force_transport_override() {
     let config = validate_integrity_config(IntegrityConfig {
         routes: vec![IntegrityRoute::user(DEFAULT_ROUTE)],


### PR DESCRIPTION
… the local loopback

`try_dispatch_local_mesh_request` (the guest-to-guest `tachyon:mesh/outbound-http` fast path) returned an immediate transport fallback on saturation or critical memory pressure without ever consulting `route.allow_overflow` or the `control_plane_override_destination`/`peer_capabilities` machinery that `system-faas-mesh-overlay` already populates. The UDS/TCP fallback it fell through to resolves to this same node, so "network = overflow" degenerated into a same-node loopback into the same semaphore.

Saturated/pressured routes with `allow_overflow` now resolve the least-pressured eligible peer via `control_plane_override_destination` (the same lookup and mTLS-capable transport the `RoutePermitError::TimedOut` overflow branch already uses) and forward the hop there, propagating hop-limit/identity headers unchanged. The local queue remains the last resort when no peer is eligible. Adds a `mode="peer"` dispatch metric (#307's `faas_mesh_dispatch_total`/`_duration_seconds`) and two tests proving the peer hop and the no-eligible-peer fallback.

See GitHub issue #309.