### PR TITLE
feat(scoping): prep require_scopes default-flip groundwork

### DIFF
--- a/core-host/src/host_core/integrity_config.rs
+++ b/core-host/src/host_core/integrity_config.rs
@@ -1038,7 +1038,8 @@ fn validate_require_scopes(routes: &[IntegrityRoute]) -> Result<()> {
             None => {
                 return Err(anyhow!(
                     "Integrity Validation Failed: route `{}` is missing a `scopes` block \
-                     and `require_scopes` is enabled on this node",
+                     and `require_scopes` is enabled on this node; call `tachyon_suggest_scopes` \
+                     for a starting scopes configuration for this route",
                     route.path
                 ));
             }
@@ -1048,7 +1049,8 @@ fn validate_require_scopes(routes: &[IntegrityRoute]) -> Result<()> {
                     if scopes.allow_all {
                         return Err(anyhow!(
                             "Integrity Validation Failed: route `{}` resolves to allow-all scopes \
-                             and `require_scopes` is enabled on this node; add explicit scope patterns",
+                             and `require_scopes` is enabled on this node; add explicit scope patterns \
+                             — call `tachyon_suggest_scopes` for a starting scopes configuration for this route",
                             route.path
                         ));
                     }

--- a/core-host/src/host_core/tests/config_validation.rs
+++ b/core-host/src/host_core/tests/config_validation.rs
@@ -102,6 +102,10 @@ fn require_scopes_flag_rejects_missing_scopes_block() {
         msg.contains("scopes") || msg.contains("require_scopes"),
         "error should reference the missing scopes block; got: {msg}"
     );
+    assert!(
+        msg.contains("tachyon_suggest_scopes"),
+        "error should point operators at the remediation tool; got: {msg}"
+    );
 }
 
 #[test]
@@ -119,6 +123,10 @@ fn require_scopes_flag_rejects_allow_all_scopes() {
     assert!(
         msg.contains("allow-all") || msg.contains("scopes"),
         "error should reference allow-all; got: {msg}"
+    );
+    assert!(
+        msg.contains("tachyon_suggest_scopes"),
+        "error should point operators at the remediation tool; got: {msg}"
     );
 }
 

--- a/docs/faas-import-scoping.md
+++ b/docs/faas-import-scoping.md
@@ -108,4 +108,6 @@ Set `requireScopes: true` in the node configuration to reject manifests without 
 
 Once telemetry shows zero `allow-all` deployments across the fleet, the default will change to deny-when-absent in a separate openspec change. No action required from operators who have completed Phase 2.
 
+**Legacy opt-out.** `require_scopes: false` remains a supported, permanent setting after the fleet default changes — it is not a deprecated flag scheduled for removal. Clusters that cannot or will not scope every deployment (fixed-manifest air-gapped clusters, single-tenant nodes where the authorization boundary doesn't matter) may pin `require_scopes: false` explicitly in their own manifest indefinitely.
+
 **Rollback at any phase:** set `scopes: allow-all` on all manifests to restore prior behavior without downtime. No data migration, no on-disk format change.

--- a/openspec/changes/require-scopes-default-flip/.openspec.yaml
+++ b/openspec/changes/require-scopes-default-flip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/require-scopes-default-flip/design.md
+++ b/openspec/changes/require-scopes-default-flip/design.md
@@ -1,0 +1,79 @@
+## Context
+
+`faas-import-scoping` (archived change `2026-05-24-faas-wit-import-scoping`) shipped a four-phase migration for per-deployment WIT import scoping:
+
+1. Phase 1 — code lands, default `allow-all`.
+2. Phase 2 — operators tighten manifests, guided by `faas_scopes_allow_all_total` / `faas_scope_denials_total`.
+3. Phase 3 — opt-in strict default: node sets `require_scopes: true`, rejecting allow-all manifests at submission.
+4. Phase 4 — flip the fleet-wide default to `true`, "behind its own openspec change" (the design doc's words).
+
+Phases 1–3 are implemented (`core-host/src/host_core/integrity_config.rs::validate_require_scopes`, the `require_scopes` field in `domain_types.rs`, the MCP tools `tachyon_suggest_scopes` / `tachyon_set_route_scopes` / `tachyon_get_scope_denials`, and the `ScopesPanel` UI). Phase 4 was deliberately left undone, gated on telemetry showing zero allow-all deployments fleet-wide. GitHub issue #311 is the tracking issue for that flip. No fleet has run Phase 2/3 long enough to produce that telemetry, so this change cannot execute Phase 4 — it can only own the decision and land the parts of the migration that are safe without fleet evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give `faas-import-scoping` the spec coverage it's missing for the `require_scopes` node flag (Phase 3), so the eventual Phase 4 delta has something to modify instead of inventing the requirement from scratch.
+- Make the Phase 3 rejection errors actionable: an operator who turns on `require_scopes` and gets rejected should be told which tool fixes it, not just what's wrong.
+- Give operators a documented, permanent way to opt out of the future fleet default (`require_scopes: false` explicit in their own manifest) so Phase 4 is not a forced migration for clusters with a legitimate reason to stay on allow-all (e.g., air-gapped clusters running a fixed, audited manifest).
+- Write down the decision criteria for Phase 4 so it's a mechanical go/no-go check for whoever opens that change, not a judgment call made from scratch.
+
+**Non-Goals:**
+
+- Flipping `require_scopes`'s default. That requires real fleet telemetry this change cannot manufacture.
+- Migrating `/metrics` and `/system/logger` in the reference `integrity.lock` off allow-all. `system-faas-guest` (the world both routes target) imports `storage-broker` and `outbound-http` unconditionally; whether an empty `scopes: {}` block (as opposed to omitting `scopes` entirely) breaks their link depends on whether wit-bindgen's generated import stubs survive dead-code elimination when unused — that's a build-and-link question, not a JSON edit, and `integrity.lock` is a *signed* manifest (re-signing needs a sealing script akin to `scripts/seal-guest-openai.js`, which doesn't exist yet for these routes). Verifying this safely is out of scope here.
+- Running the observation window itself. That's an operations activity that happens after this change merges, not a code change.
+
+## Decisions
+
+### D1. Phase 4 go/no-go criteria (written down now, checked later)
+
+**Decision.** Phase 4 (the actual default flip) may proceed once, for a continuous window of at least 2 weeks:
+- `faas_scopes_allow_all_total` is flat (no increment) across every deployment in the fleet, **and**
+- `tachyon_get_scope_denials` reports `allow_all: false` for every route on every node reachable from the MCP server, **and**
+- no node has `require_scopes: false` set *without* an accompanying documented reason (see D3) — an unexplained `false` is a signal Phase 2 isn't finished, not a legacy opt-out.
+
+**Why.** The original design left "telemetry shows zero allow-all deployments" undefined. Without a written threshold, whoever eventually opens the Phase 4 change has to reconstruct intent. Fixing the criteria now, while the rationale is fresh, turns that into a checklist.
+
+**Alternatives rejected.** A percentage threshold (e.g., "99% of deployments scoped") was considered and rejected: allow-all is an authorization bypass, not a performance metric — a single unscoped deployment in a multi-tenant cluster is a real gap, not noise to average away.
+
+### D2. Actionable error messages name the remediation tool
+
+**Decision.** `validate_require_scopes` (`core-host/src/host_core/integrity_config.rs:1034`) keeps its existing substrings (`scopes`, `require_scopes`, `allow-all`) so `config_validation.rs` assertions still pass, and appends a clause naming `tachyon_suggest_scopes` as the remediation path in both error branches (missing `scopes` block; resolves to allow-all).
+
+**Why.** This is the one piece of the migration path that doesn't need fleet telemetry to be worth doing today — every operator who already opts into Phase 3 (`require_scopes: true`) hits these errors now, and the fix already exists (`tachyon_suggest_scopes`) but isn't discoverable from the error text.
+
+**Alternatives rejected.** A structured error type carrying a `remediation` field was considered; rejected as overkill for a `Result<(), anyhow::Error>` validation path with no existing structured-error convention elsewhere in this file.
+
+### D3. Legacy opt-out is a first-class, permanent state — not a deprecation grace period
+
+**Decision.** After Phase 4 ships (in a future change), `require_scopes: false` remains a fully supported, explicit manifest setting — not a deprecated flag scheduled for removal. Document it as the answer for clusters that cannot or will not scope every deployment (fixed-manifest air-gapped clusters, single-tenant nodes where the authorization boundary genuinely doesn't matter).
+
+**Why.** Phase 4 changes the *default*, not the *option*. Conflating "we're changing what happens when you say nothing" with "we're taking away your ability to say `false`" would turn a safe default-flip into a forced migration, which is a much larger and riskier change than issue #311 asks for.
+
+### D4. Retroactively spec the `require_scopes` flag under `faas-import-scoping`
+
+**Decision.** Add the missing requirement to `openspec/specs/faas-import-scoping/spec.md` describing current Phase 3 behavior (the flag, its default, what it rejects) as a `Modified Capability` delta in this change, even though the code already exists. Do not backdate it into the archived `2026-05-24-faas-wit-import-scoping` change.
+
+**Why.** `tasks.md` in that archived change (item 8.2) implemented the flag, but no requirement was ever added to `spec.md` — a documentation gap, not a behavior gap. This change is the natural place to close it because it's already touching the same requirement area (the rejection error text) and because Phase 4's future delta needs an existing requirement to modify rather than introducing `require_scopes` from nothing.
+
+### D5. Do not touch `integrity.lock` in this change
+
+**Decision.** Leave `/metrics` and `/system/logger` on allow-all in the reference manifest. Track migrating them as a blocked prerequisite task with the link-time question spelled out, rather than guessing at an answer and shipping an unverified change to a signed artifact.
+
+**Why.** See Non-Goals — this needs a build/link verification cycle and a re-signing step this change doesn't have the tooling for. Shipping a guess here risks breaking the reference manifest CI relies on, which is a worse outcome than leaving the task open.
+
+## Risks / Trade-offs
+
+- **[Risk]** Writing down Phase 4 criteria (D1) now might not match whatever operational reality looks like when a fleet actually exists to measure. → **Mitigation.** The criteria live in this change's design doc, not in code — the future Phase 4 change can revise them with a one-line rationale if reality doesn't match, rather than starting from zero.
+- **[Risk]** Someone reads "dedicated openspec change" in issue #311 and expects the default to actually flip here. → **Mitigation.** proposal.md's "Not in this change" section and this design's Non-Goals both say so explicitly; the PR description will link back to both.
+- **[Trade-off]** Deferring the `integrity.lock` migration means the reference manifest keeps two allow-all routes indefinitely until someone does the link-time verification work. Acceptable: `/metrics` and `/system/logger` are host-internal system routes, not multi-tenant guest deployments — the authorization gap they represent is much smaller than an unscoped user-facing FaaS route.
+
+## Migration Plan
+
+This change performs no runtime migration — Phases 1–3 are already live, Phase 4 is deferred. Rollback, if needed, is simply reverting the error-message and doc changes; no manifest, wire, or schema format changes are involved.
+
+## Open Questions
+
+- **OQ1.** Who signs off that the D1 criteria are met — an individual operator per cluster, or a fleet-wide review before the Phase 4 PR is opened? **Proposed default: whoever opens the Phase 4 change includes the observation-window data in the PR description; standard review applies.** Left open for the Phase 4 change to confirm.
+- **OQ2.** Should `tachyon_get_scope_denials` gain a fleet-wide rollup (today it's per-node) to make the D1 check a single query instead of one per node? Worth doing before Phase 4 if the fleet is large enough that per-node checks are impractical. Deferred — not needed for this change.

--- a/openspec/changes/require-scopes-default-flip/proposal.md
+++ b/openspec/changes/require-scopes-default-flip/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`IntegrityConfig.require_scopes` defaults to `false` by design: the field's own doc comment and a regression test (`routes_without_scopes_pass_validation_under_default_require_scopes_false`) say the default may only flip "via a separate openspec change once telemetry shows zero allow-all deployments." That telemetry doesn't exist yet — no fleet has run the migration tooling (`tachyon_suggest_scopes`, `tachyon_set_route_scopes`, `tachyon_get_scope_denials`, the ScopesPanel UI) long enough to prove it. GitHub issue #311 asks us to own that eventual flip. This change is the "separate openspec change" the gate refers to: it stakes out the decision criteria and rollout plan now, and lands the parts of the migration that don't require fleet telemetry to be safe — an actionable rejection error and a documented legacy opt-out — without touching the default itself.
+
+## What Changes
+
+- Add the missing spec coverage for the `require_scopes` node-level flag and its Phase 3 opt-in behavior to `faas-import-scoping` (this was implemented in the `faas-wit-import-scoping` change but never given its own spec requirement).
+- Make the `require_scopes: true` rejection errors in `validate_require_scopes` (`core-host/src/host_core/integrity_config.rs`) actionable: name `tachyon_suggest_scopes` as the remediation path for both the "missing scopes block" and "resolves to allow-all" cases.
+- Document an explicit legacy opt-out: operators who complete Phase 2 tightening but are not ready for a fleet-wide strict default may pin `require_scopes: false` in their own manifest to keep prior behavior even after the fleet default changes in a future change.
+- Record the observation-window decision criteria (what "zero allow-all deployments" means operationally, how long the window runs, who signs off) that gate the actual default flip.
+- **Not in this change**: flipping `require_scopes`'s default to `true`, and migrating the remaining allow-all system routes (`/metrics`, `/system/logger`) in the reference `integrity.lock`. Both require evidence or verification this change doesn't have — real fleet telemetry for the former, a rebuilt-and-relinked guest check plus manifest re-signing for the latter (`scripts/seal-guest-openai.js` shows re-signing isn't a trivial JSON edit). Both are tracked as blocked prerequisite tasks.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `faas-import-scoping`: adds the previously-unspecified `require_scopes` node-flag requirement (Phase 3 opt-in strict validation), makes its rejection errors name the remediation tool, and adds the legacy-opt-out guarantee for the eventual Phase 4 default change.
+
+## Impact
+
+- **Code**: `core-host/src/host_core/integrity_config.rs` (`validate_require_scopes` error strings only — no behavior change to what is accepted/rejected); `core-host/src/host_core/tests/config_validation.rs` (assert the new error text).
+- **Docs**: `docs/faas-import-scoping.md` Phase 4 section gains the legacy opt-out note.
+- **Specs**: `openspec/specs/faas-import-scoping/spec.md` gains a requirement documenting `require_scopes` and its error-message contract.
+- **No API/wire/manifest-schema change**: `require_scopes` already exists and already defaults to `false`; this change only improves messaging and documentation around it.
+- **Blocked follow-up work** (tracked in `tasks.md`, not executed here): running the telemetry observation window, migrating `/metrics` and `/system/logger` in `integrity.lock` to explicit scopes, and the actual default flip PR once the observation window closes clean.

--- a/openspec/changes/require-scopes-default-flip/specs/faas-import-scoping/spec.md
+++ b/openspec/changes/require-scopes-default-flip/specs/faas-import-scoping/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Node-level `require_scopes` flag enforces explicit scopes at submission
+
+The node configuration SHALL expose a `require_scopes` boolean, defaulting to `false`. When `true`, manifest validation SHALL reject at submission time any route whose `scopes` block is absent, or whose `scopes` resolve to `allow-all`. Rejection errors SHALL name the offending route and SHALL name `tachyon_suggest_scopes` as the tool that produces a starting scopes configuration for that route.
+
+#### Scenario: Route missing a scopes block under require_scopes=true
+- **WHEN** `require_scopes` is `true`
+- **AND** a route in the manifest has no `scopes` block
+- **THEN** manifest validation MUST reject the manifest
+- **AND** the error MUST name the route's path
+- **AND** the error MUST name `tachyon_suggest_scopes` as the remediation tool
+
+#### Scenario: Route resolves to allow-all under require_scopes=true
+- **WHEN** `require_scopes` is `true`
+- **AND** a route's `scopes` block resolves to `allow-all` (either the literal string `"allow-all"` or an equivalent wildcard shape)
+- **THEN** manifest validation MUST reject the manifest
+- **AND** the error MUST name the route's path
+- **AND** the error MUST name `tachyon_suggest_scopes` as the remediation tool
+
+#### Scenario: Route carries explicit non-allow-all scopes under require_scopes=true
+- **WHEN** `require_scopes` is `true`
+- **AND** every route in the manifest has an explicit `scopes` block that does not resolve to `allow-all`
+- **THEN** manifest validation MUST succeed
+
+#### Scenario: Default require_scopes=false preserves existing manifests
+- **WHEN** `require_scopes` is `false` (the default; the flag is absent from the manifest)
+- **AND** a route has no `scopes` block
+- **THEN** manifest validation MUST succeed (the route resolves to `allow-all` at runtime, per the `faas-import-scoping` migration-default requirement)
+
+### Requirement: Explicit `require_scopes: false` remains a supported operator choice
+
+`require_scopes: false` SHALL remain a valid, permanent manifest setting regardless of what value the field defaults to in later changes. A node that explicitly sets `require_scopes: false` SHALL continue to accept manifests with absent or allow-all `scopes` blocks, independent of any future change to the field's default.
+
+#### Scenario: Cluster pins require_scopes=false ahead of a future default change
+- **WHEN** a node's manifest explicitly sets `require_scopes: false`
+- **AND** a route has no `scopes` block
+- **THEN** manifest validation MUST succeed, regardless of the compiled-in default value of `require_scopes`

--- a/openspec/changes/require-scopes-default-flip/tasks.md
+++ b/openspec/changes/require-scopes-default-flip/tasks.md
@@ -1,0 +1,22 @@
+## 1. Actionable rejection errors
+
+- [x] 1.1 In `core-host/src/host_core/integrity_config.rs::validate_require_scopes`, extend the "missing `scopes` block" error to name `tachyon_suggest_scopes` as the remediation tool, keeping the existing `scopes`/`require_scopes` substrings intact.
+- [x] 1.2 Extend the "resolves to allow-all" error the same way, keeping the existing `allow-all`/`scopes` substrings intact.
+- [x] 1.3 Update `core-host/src/host_core/tests/config_validation.rs` (`require_scopes_flag_rejects_missing_scopes_block`, `require_scopes_flag_rejects_allow_all_scopes`) to assert the new error text names `tachyon_suggest_scopes`.
+- [x] 1.4 Run `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --features core-host/ai-inference -- -D warnings -D clippy::unwrap_used` for the touched crate.
+
+## 2. Legacy opt-out documentation
+
+- [x] 2.1 Add a note to `docs/faas-import-scoping.md`'s "Phase 4 — flip the default" section documenting that `require_scopes: false` remains a supported, permanent explicit setting after the fleet default changes — not a deprecated flag.
+- [x] 2.2 Cross-link the new note to the rollback note already present in that section so operators find both together.
+
+## 3. Blocked prerequisites (do not implement in this change)
+
+- [ ] 3.1 **[BLOCKED — needs real fleet telemetry]** Run the 2+ week observation window against the D1 criteria in `design.md`: `faas_scopes_allow_all_total` flat fleet-wide, `tachyon_get_scope_denials` reporting `allow_all: false` for every route, no unexplained `require_scopes: false`.
+- [ ] 3.2 **[BLOCKED — needs link-time verification + re-signing tooling]** Migrate `/metrics` and `/system/logger` in the reference `integrity.lock` off allow-all: confirm whether an explicit empty `scopes: {}` block breaks `system-faas-guest` linking for these two components (they don't call `storage-broker`/`outbound-http` via WIT, only via mounted volumes), then re-sign the manifest with a sealing script analogous to `scripts/seal-guest-openai.js`.
+- [ ] 3.3 **[BLOCKED — depends on 3.1]** Open the Phase 4 openspec change that flips `require_scopes`'s compiled-in default to `true`, citing the closed observation window from 3.1 in its proposal.
+
+## 4. Pre-merge validation (for tasks 1–2 only)
+
+- [x] 4.1 `cargo test -p core-host` covering the modified `config_validation.rs` tests.
+- [x] 4.2 Confirm no other test asserts the exact prior wording of the two `validate_require_scopes` error strings (grep for the literal phrases before changing them).


### PR DESCRIPTION
## Summary

Refs #311. That issue's own plan gates the actual `require_scopes` default flip on a 2-4 week fleet telemetry observation window showing zero allow-all deployments — that data doesn't exist yet, so this PR does not flip the default. Instead it:

- Adds a dedicated OpenSpec change (`openspec/changes/require-scopes-default-flip/`) that owns the eventual flip decision: written go/no-go telemetry criteria, and a permanent `require_scopes: false` legacy opt-out guarantee for clusters that never fully migrate.
- Makes the `require_scopes: true` rejection errors actionable — they now name `tachyon_suggest_scopes` as the remediation tool (`core-host/src/host_core/integrity_config.rs::validate_require_scopes`).
- Documents the legacy opt-out in `docs/faas-import-scoping.md`'s Phase 4 section.

**Not in this PR** (tracked as explicitly blocked tasks in the change's `tasks.md`): running the telemetry observation window, migrating the remaining allow-all system routes (`/metrics`, `/system/logger`) in the reference `integrity.lock` (needs link-time verification + re-signing tooling that doesn't exist), and the actual default flip. This PR does not close #311.

## Test plan
- [x] `cargo test -p core-host config_validation` — all 40 tests pass, including the two updated `require_scopes_flag_rejects_*` assertions
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p core-host --all-targets --features core-host/ai-inference -- -D warnings -D clippy::unwrap_used`
- [x] `openspec validate require-scopes-default-flip` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)