### PR TITLE
fix(renovate): hold next-gen RustCrypto crates for dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,22 @@
       "description": "All GitHub Actions updates (majors included) in a single PR — action bumps are low-risk and reviewed together.",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"
+    },
+    {
+      "description": "Next-gen RustCrypto wave — rand_core 0.9+ renamed the `getrandom` feature to `os_rng`, and der/spki/pkcs8/const-oid/x509-cert/p256/ed25519-dalek follow suit. Renovate sees 0.x minors but this is a coordinated breaking code migration (issue #362). Held for dashboard approval so it stops breaking the weekly group.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "rand_core",
+        "der",
+        "spki",
+        "pkcs8",
+        "const-oid",
+        "x509-cert",
+        "p256",
+        "ed25519-dalek"
+      ],
+      "groupName": "rustcrypto-next-gen",
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Problème

La PR groupée #360 (`renovate/all-minor-patch`) échoue en résolution cargo :

```
package `system-faas-cert-manager` depends on `rand_core` with feature `getrandom`
but `rand_core` does not have that feature.
```

`rand_core` 0.9+ a renommé la feature `getrandom` en `os_rng`, et toute la vague next-gen RustCrypto (`der` 0.8, `spki` 0.8, `pkcs8` 0.11, `const-oid` 0.10, `x509-cert` 0.3, `p256` 0.14, `ed25519-dalek` v3) est une migration de code coordonnée — Renovate la voit comme des minors 0.x et l'a incluse dans le groupe hebdomadaire.

## Solution

Nouvelle `packageRule` : ces 8 crates vont dans un groupe dédié `rustcrypto-next-gen` avec `dependencyDashboardApproval: true` — elles attendent dans le Dependency Dashboard (#9) au lieu de casser le groupe hebdomadaire. La migration est trackée dans #362.

Après merge : rebase de #360 via le dashboard → le groupe se régénère sans ces crates → mergeable via la fast lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)