### PR TITLE
fix(renovate): hold node-registry's sha2 0.10 jump with the RustCrypto group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,14 @@
       ],
       "groupName": "rustcrypto-next-gen",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "sha2 0.10 → 0.11 is part of the same wave where it meets rsa 0.9 (digest 0.10): node-registry's RS256 JWT verification (`VerifyingKey::<Sha256>`) stops compiling with a digest-0.11 sha2. Only the 0.10 jump is held — crates already on 0.11 keep getting patches through the weekly group. See issue #362.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["sha2"],
+      "matchCurrentVersion": "<0.11",
+      "groupName": "rustcrypto-next-gen",
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Problème

Le groupe régénéré #360 échouait encore (`quality` + `build-guests`) :

```
error[E0277]: the trait bound `Sha256: rsa::signature::digest::FixedOutput` is not satisfied
  --> systems/system-faas-node-registry/src/jwt.rs:30:25
note: there are multiple different versions of crate `digest` in the dependency graph
```

`sha2` 0.10→0.11 dans `system-faas-node-registry` est couplé à `rsa` 0.9 (resté sur `digest` 0.10) : la vérification JWT RS256 ne compile plus. C'est la même vague RustCrypto next-gen que #363 — il manquait `sha2`.

## Solution

Règle de retenue **ciblée** : `matchPackageNames: ["sha2"]` + `matchCurrentVersion: "<0.11"` → seul le saut 0.10→0.11 de node-registry est retenu dans le groupe `rustcrypto-next-gen` (approbation dashboard, issue #362). Les crates déjà en sha2 0.11 continuent de recevoir leurs patchs via le groupe hebdomadaire.

Après merge : nouveau rebase de #360 via le dashboard → le groupe se régénère sans le bump sha2 → mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)