### PR TITLE
fix(ai-inference): update Candle CUDA Graph fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-flashinfer-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "cudaforge",
 ]
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "candle-core",
  "half",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-7#6af45bccd21bb7b4db40fe30430c486c1de44d99"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -76,14 +76,14 @@ arc-swap = "1.7"
 axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
-candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-7", version = "0.11.0", optional = true }
-candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-7", version = "0.11.0", optional = true, default-features = false }
-candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-7", version = "0.11.0", optional = true }
-candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-7", version = "0.11.0", optional = true }
+candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
+candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true, default-features = false }
+candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
+candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
 # Standard transformer architectures (Llama family) for running real, uploaded
 # checkpoints. Weights are mmapped from the model directory at runtime — never
 # compiled into the Tachyon artifact.
-candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-7", version = "0.11.0", optional = true, default-features = false }
+candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true, default-features = false }
 parallel-topology = { path = "../crates/parallel-topology", optional = true }
 # Same cudarc version `candle-core`'s CUDA backend already vendors (see
 # Cargo.lock), so this reuses one NCCL binding instead of introducing a


### PR DESCRIPTION
## Change
Updates all optional Candle crates from `tachyon-v0.11.0-7` to `tachyon-v0.11.0-8` (`69b36162`).

## Why
Candle #17 now retains capture event-tracking state for the full `CudaGraph` lifetime and trims the graph memory pool when a graph is destroyed. This targets Tachyon's failing second independent `cuda_graph_decode` request.

## Validation
- `cargo metadata --locked --no-deps` passed.
- `cargo check -p core-host --features ai-inference` started successfully but exceeded the local 10-minute command limit during a cold rebuild; this environment has no CUDA toolkit.
- `cuda-quality` is the required real-hardware validation and runs the second-request capture/replay proof.