### PR TITLE
feat(observability): add mesh dispatch locality SLO

### DIFF
--- a/docs/mesh-dispatch-locality-slo.md
+++ b/docs/mesh-dispatch-locality-slo.md
@@ -1,0 +1,57 @@
+# Mesh Dispatch Locality SLO
+
+## Objective
+
+For a single-node Tachyon deployment, at least 95% of eligible internal mesh
+dispatches must use `in_process` over a rolling 15-minute window. The alert
+requires at least 100 eligible dispatches and remains pending for 10 minutes
+before it fires at warning severity.
+
+Eligible traffic is every `faas_mesh_dispatch_total` sample except
+`reason="remote"`. Remote traffic is intentional and cannot satisfy a
+single-node locality objective. `saturated` and `pressure` remain in the
+denominator because they reveal the local fallbacks the SLO is designed to
+detect.
+
+## Enabling the Alert
+
+`manifests/prometheus-mesh-dispatch-slo.yaml` is a Prometheus Operator
+`PrometheusRule`. Apply it only after the core-host scrape target is labelled:
+
+```yaml
+labels:
+  tachyon_mesh_topology: single-node
+```
+
+Do not set that label for multi-node deployments. The rule deliberately has no
+series for targets without this label, so it cannot misclassify intentional
+remote dispatch as a locality regression.
+
+## PromQL
+
+The rule records the eligible count and in-process ratio before evaluating:
+
+```promql
+sum by (job, instance, tachyon_mesh_topology) (
+  increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+)
+/
+clamp_min(
+  sum by (job, instance, tachyon_mesh_topology) (
+    increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",reason!="remote"}[15m])
+  ),
+  1
+)
+```
+
+`MeshDispatchLocalityDegraded` fires when the ratio is below `0.95`, the
+eligible count is at least `100`, and both conditions persist for `10m`.
+
+## Response
+
+1. Inspect `faas_mesh_dispatch_total` split by `mode` and `reason` for the
+   affected `job` and `instance`.
+2. If `saturated` dominates, review route concurrency limits and queue depth.
+3. If `pressure` dominates, inspect host memory pressure and admission policy.
+4. If neither fallback reason explains the ratio, investigate the local mesh
+   route resolution before relaxing the threshold.

--- a/docs/mesh-dispatch-locality-slo.md
+++ b/docs/mesh-dispatch-locality-slo.md
@@ -32,16 +32,15 @@ remote dispatch as a locality regression.
 The rule records the eligible count and in-process ratio before evaluating:
 
 ```promql
-sum by (job, instance, tachyon_mesh_topology) (
-  increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+(
+  sum by (job, instance, tachyon_mesh_topology) (
+    increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+  )
+  or on (job, instance, tachyon_mesh_topology)
+  (0 * tachyon:mesh_dispatch_eligible_total:increase15m)
 )
 /
-clamp_min(
-  sum by (job, instance, tachyon_mesh_topology) (
-    increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",reason!="remote"}[15m])
-  ),
-  1
-)
+clamp_min(tachyon:mesh_dispatch_eligible_total:increase15m, 1)
 ```
 
 `MeshDispatchLocalityDegraded` fires when the ratio is below `0.95`, the

--- a/manifests/prometheus-mesh-dispatch-slo.yaml
+++ b/manifests/prometheus-mesh-dispatch-slo.yaml
@@ -1,0 +1,40 @@
+# Apply only on clusters that run the Prometheus Operator. The scrape target
+# for a single-node Tachyon deployment must carry
+# tachyon_mesh_topology="single-node"; multi-node targets must not.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tachyon-mesh-dispatch-slo
+  labels:
+    app: tachyon-mesh
+spec:
+  groups:
+    - name: tachyon-mesh-dispatch-slo
+      interval: 1m
+      rules:
+        - record: tachyon:mesh_dispatch_eligible_total:increase15m
+          expr: |
+            sum by (job, instance, tachyon_mesh_topology) (
+              increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",reason!="remote"}[15m])
+            )
+        - record: tachyon:mesh_dispatch_in_process_ratio:increase15m
+          expr: |
+            sum by (job, instance, tachyon_mesh_topology) (
+              increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+            )
+            /
+            clamp_min(tachyon:mesh_dispatch_eligible_total:increase15m, 1)
+        - alert: MeshDispatchLocalityDegraded
+          expr: |
+            (tachyon:mesh_dispatch_in_process_ratio:increase15m{tachyon_mesh_topology="single-node"} < 0.95)
+            and on (job, instance, tachyon_mesh_topology)
+            (tachyon:mesh_dispatch_eligible_total:increase15m{tachyon_mesh_topology="single-node"} >= 100)
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Single-node mesh dispatch is falling back from in-process execution
+            description: >-
+              In-process dispatch has remained below 95% of eligible internal
+              mesh dispatches for 10 minutes. Inspect saturated and pressure
+              fallback reasons before changing the routing policy.

--- a/manifests/prometheus-mesh-dispatch-slo.yaml
+++ b/manifests/prometheus-mesh-dispatch-slo.yaml
@@ -19,8 +19,12 @@ spec:
             )
         - record: tachyon:mesh_dispatch_in_process_ratio:increase15m
           expr: |
-            sum by (job, instance, tachyon_mesh_topology) (
-              increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+            (
+              sum by (job, instance, tachyon_mesh_topology) (
+                increase(faas_mesh_dispatch_total{tachyon_mesh_topology="single-node",mode="in_process",reason!="remote"}[15m])
+              )
+              or on (job, instance, tachyon_mesh_topology)
+              (0 * tachyon:mesh_dispatch_eligible_total:increase15m)
             )
             /
             clamp_min(tachyon:mesh_dispatch_eligible_total:increase15m, 1)

--- a/openspec/changes/add-mesh-dispatch-slo-alert/design.md
+++ b/openspec/changes/add-mesh-dispatch-slo-alert/design.md
@@ -1,0 +1,63 @@
+## Context
+
+Issue #307 already emits `faas_mesh_dispatch_total{mode,reason}` and
+`faas_mesh_dispatch_duration_seconds{mode}`. The metrics do not, however,
+state what percentage of local traffic must stay in-process or tell an
+operator when that property regresses. The repository has raw Kubernetes
+manifests but no shared Prometheus Operator configuration, so the alert must
+be self-contained and explicitly opt in to the topology where it is valid.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a measurable 95% in-process locality objective over 15 minutes.
+- Ship a reusable PrometheusRule and an operator runbook.
+- Avoid false alerts from low request volume and multi-node deployments.
+
+**Non-Goals:**
+- Change dispatch routing or add labels to the request path.
+- Infer cluster topology at runtime.
+- Enforce a locality objective for multi-node deployments.
+
+## Decisions
+
+### Fixed locality objective with a traffic floor
+
+The objective is at least 95% `in_process` dispatches among eligible internal
+dispatches in a rolling 15-minute window. The alert only evaluates windows
+with 100 or more eligible dispatches and must remain breached for 10 minutes.
+Eligible dispatches exclude `reason="remote"`; saturation and pressure
+fallbacks remain in the denominator.
+
+### Topology is an explicit scrape label
+
+The host exports no authoritative single-node topology metric. The rule
+therefore selects only targets labelled `tachyon_mesh_topology="single-node"`
+by Prometheus scrape configuration, keeping multi-node traffic out of the
+locality objective without changing application metrics.
+
+### PrometheusRule plus a versioned runbook
+
+The repository ships an optional Prometheus Operator `PrometheusRule` and a
+runbook. Operations can enable, tune, or roll back policy without changing the
+request path.
+
+## Risks / Trade-offs
+
+- [A scrape target lacks the topology label] -> The rule emits no series; the
+  runbook makes the required label explicit.
+- [A low-throughput deployment regresses] -> The 100-request floor suppresses
+  noise; operators can inspect the existing counters or tune a local rule.
+- [The threshold is too strict for a workload] -> The optional baseline rule
+  documents the adjustment point.
+
+## Migration Plan
+
+1. Add `tachyon_mesh_topology="single-node"` to the core-host scrape target.
+2. Apply the PrometheusRule and observe the 15-minute recording rules.
+3. Remove the PrometheusRule to roll back alerting; no host restart is needed.
+
+## Open Questions
+
+None. The baseline is 95% over 15 minutes, 100 eligible requests, and a
+10-minute alert hold.

--- a/openspec/changes/add-mesh-dispatch-slo-alert/proposal.md
+++ b/openspec/changes/add-mesh-dispatch-slo-alert/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The mesh dispatch metrics delivered for #307 show whether internal traffic used
+the in-process path, but they do not define the expected healthy ratio or
+produce an operator-visible signal when that ratio regresses. A single-node
+deployment can silently fall back to UDS or TCP without violating a concrete
+service objective.
+
+## What Changes
+
+- Define a single-node mesh dispatch SLO: at least 95% of eligible internal
+  dispatches use `in_process` over a rolling 15-minute window.
+- Add a Prometheus alert that fires only after the ratio remains below the
+  objective for 10 minutes and only when at least 100 eligible dispatches were
+  observed in the window.
+- Require the alert to be scoped by the externally supplied
+  `tachyon_mesh_topology="single-node"` target label, so multi-node traffic is
+  not evaluated against a locality objective it cannot satisfy.
+- Document the PromQL expression, its exclusions, and its operator response.
+
+## Capabilities
+
+### New Capabilities
+
+- `mesh-dispatch-locality-slo`: Defines the single-node in-process dispatch
+  objective and its Prometheus alerting contract.
+
+### Modified Capabilities
+
+- `compute-observability`: The Observability documentation includes the active
+  dispatch locality SLO and alert semantics alongside the existing metrics.
+
+## Impact
+
+- Adds a Prometheus Operator `PrometheusRule` manifest and an operator runbook.
+- Extends OpenSpec observability requirements without changing the request path
+  or the existing metric names and labels.

--- a/openspec/changes/add-mesh-dispatch-slo-alert/specs/compute-observability/spec.md
+++ b/openspec/changes/add-mesh-dispatch-slo-alert/specs/compute-observability/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Observability documentation defines mesh dispatch locality policy
+The observability documentation SHALL define the single-node mesh dispatch
+locality objective, its `tachyon_mesh_topology="single-node"` scope, and the
+`MeshDispatchLocalityDegraded` alert semantics alongside the existing metrics.
+
+#### Scenario: Operator inspects locality alert policy
+- **WHEN** an operator consults the mesh dispatch observability documentation
+- **THEN** it identifies the 95% in-process objective, 15-minute window,
+  100-request minimum, and 10-minute alert hold
+- **AND** it explains that `reason="remote"` samples are excluded

--- a/openspec/changes/add-mesh-dispatch-slo-alert/specs/mesh-dispatch-locality-slo/spec.md
+++ b/openspec/changes/add-mesh-dispatch-slo-alert/specs/mesh-dispatch-locality-slo/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Single-node mesh dispatch locality SLO
+The mesh SHALL maintain at least 95% `in_process` dispatches among eligible
+internal dispatches over a rolling 15-minute window for Prometheus targets
+labelled `tachyon_mesh_topology="single-node"`. Eligible dispatches SHALL
+include all `faas_mesh_dispatch_total` modes except samples whose `reason` is
+`remote`.
+
+#### Scenario: Healthy single-node dispatch mix
+- **WHEN** at least 100 eligible dispatches occur in 15 minutes and 95% or more use `mode="in_process"`
+- **THEN** the locality objective is met
+- **AND** no locality degradation alert is active
+
+#### Scenario: Remote dispatches do not dilute the locality ratio
+- **WHEN** a single-node target records dispatches with `reason="remote"`
+- **THEN** those samples are excluded from the locality SLO denominator
+- **AND** saturation and pressure fallbacks remain in the denominator
+
+### Requirement: Sustained locality degradation alerts operators
+The deployment SHALL provide an optional `MeshDispatchLocalityDegraded`
+Prometheus alert for labelled single-node targets. It SHALL fire only when at
+least 100 eligible dispatches were observed in 15 minutes and the in-process
+ratio remains below 95% for 10 minutes.
+
+#### Scenario: Sustained fallback triggers the alert
+- **WHEN** the in-process ratio is below 95% for a labelled single-node target
+- **AND** the 15-minute eligible dispatch count is at least 100
+- **AND** the breach persists for 10 minutes
+- **THEN** `MeshDispatchLocalityDegraded` fires with a warning severity
+
+#### Scenario: Sparse traffic does not trigger the alert
+- **WHEN** fewer than 100 eligible dispatches occur in the 15-minute window
+- **THEN** `MeshDispatchLocalityDegraded` does not fire

--- a/openspec/changes/add-mesh-dispatch-slo-alert/tasks.md
+++ b/openspec/changes/add-mesh-dispatch-slo-alert/tasks.md
@@ -1,0 +1,13 @@
+## 1. Alert policy
+
+- [x] 1.1 Add the optional single-node PrometheusRule with the 95% locality objective, 15-minute window, 100-request floor, and 10-minute hold.
+- [x] 1.2 Add a runbook documenting the scrape label, PromQL, exclusions, and operator response.
+
+## 2. Product documentation
+
+- [x] 2.1 Add the locality SLO and alert semantics to the canonical compute-observability OpenSpec.
+
+## 3. Verification
+
+- [x] 3.1 Add a focused test that guards the shipped alert expression and runbook contract.
+- [x] 3.2 Validate the OpenSpec change and the affected test suite.

--- a/openspec/specs/compute-observability/spec.md
+++ b/openspec/specs/compute-observability/spec.md
@@ -50,6 +50,26 @@ Tauri commands respectively.
 - **AND** it shows the average latency per dispatch mode
 - **AND** it identifies the backing Prometheus metrics as `faas_mesh_dispatch_total{mode,reason}` and `faas_mesh_dispatch_duration_seconds{mode}`
 
+### Requirement: Single-node mesh dispatch locality is documented
+The observability documentation SHALL provide an optional
+`MeshDispatchLocalityDegraded` Prometheus alert for scrape targets labelled
+`tachyon_mesh_topology="single-node"`. The alert SHALL require at least 100
+eligible internal dispatches in a rolling 15-minute window, SHALL fire when
+less than 95% use `in_process` for 10 minutes, and SHALL exclude samples whose
+reason is `remote` from the ratio.
+
+#### Scenario: Sustained local fallback raises an alert
+- **WHEN** a labelled single-node target records at least 100 eligible internal
+  dispatches in 15 minutes
+- **AND** less than 95% of those dispatches use `in_process` for 10 minutes
+- **THEN** `MeshDispatchLocalityDegraded` fires with warning severity
+- **AND** `saturated` and `pressure` samples remain in the denominator
+
+#### Scenario: Multi-node and sparse traffic are not alerted
+- **WHEN** a target has no `tachyon_mesh_topology="single-node"` scrape label
+- **OR** fewer than 100 eligible dispatches occur in the 15-minute window
+- **THEN** `MeshDispatchLocalityDegraded` does not fire
+
 #### Scenario: Manual refresh updates all three sections
 - **GIVEN** the panel is open
 - **WHEN** the operator clicks the refresh control

--- a/tests/observability/mesh_dispatch_slo.test.mjs
+++ b/tests/observability/mesh_dispatch_slo.test.mjs
@@ -16,6 +16,10 @@ test("single-node mesh dispatch alert preserves the locality SLO contract", () =
   assert.match(rule, /tachyon_mesh_topology="single-node"/);
   assert.match(rule, /reason!="remote"/);
   assert.match(rule, /mode="in_process"/);
+  assert.match(
+    rule,
+    /or on \(job, instance, tachyon_mesh_topology\)\s+\(0 \* tachyon:mesh_dispatch_eligible_total:increase15m\)/,
+  );
   assert.match(rule, /< 0\.95/);
   assert.match(rule, />= 100/);
   assert.match(rule, /for: 10m/);

--- a/tests/observability/mesh_dispatch_slo.test.mjs
+++ b/tests/observability/mesh_dispatch_slo.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const readRepositoryFile = (path) => readFileSync(resolve(repositoryRoot, path), "utf8");
+
+test("single-node mesh dispatch alert preserves the locality SLO contract", () => {
+  const rule = readRepositoryFile("manifests/prometheus-mesh-dispatch-slo.yaml");
+  const runbook = readRepositoryFile("docs/mesh-dispatch-locality-slo.md");
+
+  assert.match(rule, /kind: PrometheusRule/);
+  assert.match(rule, /alert: MeshDispatchLocalityDegraded/);
+  assert.match(rule, /tachyon_mesh_topology="single-node"/);
+  assert.match(rule, /reason!="remote"/);
+  assert.match(rule, /mode="in_process"/);
+  assert.match(rule, /< 0\.95/);
+  assert.match(rule, />= 100/);
+  assert.match(rule, /for: 10m/);
+
+  assert.match(runbook, /at least 95%/);
+  assert.match(runbook, /at least 100 eligible dispatches/);
+  assert.match(runbook, /tachyon_mesh_topology: single-node/);
+  assert.match(runbook, /reason="remote"/);
+});


### PR DESCRIPTION
## What changed
- Defines a 95% in-process locality SLO for labelled single-node mesh deployments.
- Adds the optional `MeshDispatchLocalityDegraded` PrometheusRule: 15-minute window, 100-dispatch floor, 10-minute hold, and exclusion of `reason=remote`.
- Adds an operator runbook, OpenSpec change, canonical observability specification, and a focused contract test.

## Why
The dispatch metrics delivered in #307 had no explicit locality target or alert for sustained fallback to UDS/TCP.

## Validation
- `node --test tests/observability/mesh_dispatch_slo.test.mjs`
- `openspec validate add-mesh-dispatch-slo-alert --strict`
- `openspec validate --all --strict`
- `git diff --check`

Fixes #307