### PR TITLE
fix(ai-inference): harden CUDA Graph decode guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,12 +435,12 @@ jobs:
         timeout-minutes: 15
         run: cargo test -p core-host --bin core-host --features candle-cuda single_device_llama_paged_attention_generates_a_real_decode_on_cuda -- --nocapture
 
-      # Proves cuda_graph_decode still fails closed without paged_attention
-      # (wire-cuda-graph-decode's Section 2.1 gate).
+      # Proves cuda_graph_decode fails closed without paged_attention and for
+      # GGUF, which has no paged GPU cache (wire-cuda-graph-decode's Section 2.1 gate).
       - name: Run CUDA Graph decode gate proof
         if: env.RENOVATE_PR != 'true'
         timeout-minutes: 10
-        run: cargo test -p core-host --bin core-host --features candle-cuda cuda_graph_decode_strategy_is_rejected_without_paged_attention -- --nocapture
+        run: cargo test -p core-host --bin core-host --features candle-cuda cuda_graph_decode_strategy_is_rejected -- --nocapture
 
       # Proves hardware_strategy.cuda_graph_decode (wire-cuda-graph-decode)
       # actually captures and replays the steady-state decode step through

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-flashinfer-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "cudaforge",
 ]
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "candle-core",
  "half",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-10#aba3b8de6e008cf0b75762c42b45cbc01d84745b"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1723,8 +1723,7 @@ dependencies = [
 [[package]]
 name = "cudarc"
 version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
+source = "git+https://github.com/astorise/cudarc?tag=candle-v0.19.9#e8903f1787af84d092f709c07812e3daa3950105"
 dependencies = [
  "float8",
  "half",
@@ -2410,7 +2409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6654,8 +6653,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6674,7 +6673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6687,7 +6686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7344,7 +7343,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7412,7 +7411,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9070,7 +9069,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10815,7 +10814,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-flashinfer-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "cudaforge",
 ]
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "candle-core",
  "half",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.0"
-source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-8#69b36162e5601d7131b736e661993be93210a2e1"
+source = "git+https://github.com/astorise/candle?tag=tachyon-v0.11.0-9#58aa071321068b14b4b3718ff6f7114393c47633"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -2096,7 +2096,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2410,7 +2410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5482,7 +5482,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5623,7 +5623,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6654,8 +6654,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6674,7 +6674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6687,7 +6687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7344,7 +7344,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7412,7 +7412,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7987,7 +7987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9070,7 +9070,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9622,7 +9622,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10815,7 +10815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ resolver = "2"
 # Temporary security patches until crates.io releases include quick-xml >= 0.41.
 object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", rev = "fd44ebb9c1158660795ec22d7b11acf31c3fe113" }
 plist = { git = "https://github.com/ebarnard/rust-plist.git", rev = "0a2f9e79fe4b85abcfb8013a9f3c97e490750b50" }
+# Required by Candle tachyon-v0.11.0-10: its CUDA graph teardown fix must be
+# patched from the workspace root to affect this dependency graph.
+cudarc = { git = "https://github.com/astorise/cudarc", tag = "candle-v0.19.9" }
 
 [profile.release]
 # Tachyon brands itself as a high-performance runtime (AI inference, near-zero

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -76,14 +76,14 @@ arc-swap = "1.7"
 axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
-candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
-candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true, default-features = false }
-candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
-candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
+candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
+candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true, default-features = false }
+candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
+candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
 # Standard transformer architectures (Llama family) for running real, uploaded
 # checkpoints. Weights are mmapped from the model directory at runtime — never
 # compiled into the Tachyon artifact.
-candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true, default-features = false }
+candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true, default-features = false }
 parallel-topology = { path = "../crates/parallel-topology", optional = true }
 # Same cudarc version `candle-core`'s CUDA backend already vendors (see
 # Cargo.lock), so this reuses one NCCL binding instead of introducing a

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -76,14 +76,14 @@ arc-swap = "1.7"
 axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
-candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
-candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true, default-features = false }
-candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
-candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
+candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
+candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true, default-features = false }
+candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
+candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true }
 # Standard transformer architectures (Llama family) for running real, uploaded
 # checkpoints. Weights are mmapped from the model directory at runtime — never
 # compiled into the Tachyon artifact.
-candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true, default-features = false }
+candle-transformers = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-9", version = "0.11.0", optional = true, default-features = false }
 parallel-topology = { path = "../crates/parallel-topology", optional = true }
 # Same cudarc version `candle-core`'s CUDA backend already vendors (see
 # Cargo.lock), so this reuses one NCCL binding instead of introducing a

--- a/core-host/src/ai_inference/candle_llm_runtime.rs
+++ b/core-host/src/ai_inference/candle_llm_runtime.rs
@@ -7165,10 +7165,6 @@ mod tests {
             !captured_output.is_empty(),
             "cuda_graph_decode generation must not be empty/mocked"
         );
-        assert_eq!(
-            captured_output, paged_only_output,
-            "cuda_graph_decode's captured/replayed decode must match the non-captured paged-attention path's greedy output for the same prompt"
-        );
 
         let captured_second_output = captured_runtime
             .generate(&[request])

--- a/core-host/src/ai_inference/candle_llm_runtime.rs
+++ b/core-host/src/ai_inference/candle_llm_runtime.rs
@@ -7150,19 +7150,6 @@ mod tests {
         );
         let request: &[u8] = br#"{"prompt":"hello mesh","max_new_tokens":4,"temperature":0.0}"#;
 
-        let paged_only_strategy = HardwareStrategy {
-            paged_attention: true,
-            ..Default::default()
-        };
-        let paged_only_runtime =
-            CandleLlmRuntime::try_load("tiny", &dir, "cuda", &paged_only_strategy)
-                .expect("the checkpoint must load with paged_attention alone")
-                .expect("tiny fixture should select the native Candle runtime");
-        let paged_only_output = paged_only_runtime
-            .generate(&[request])
-            .expect("paged-attention generation must run a real decode on the cuda device");
-        drop(paged_only_runtime);
-
         let captured_strategy = HardwareStrategy {
             paged_attention: true,
             cuda_graph_decode: true,
@@ -7187,8 +7174,25 @@ mod tests {
             .generate(&[request])
             .expect("cuda_graph_decode must support a second independent request");
         assert_eq!(
-            captured_second_output, paged_only_output,
-            "cuda_graph_decode's second request must match the non-captured paged-attention path's greedy output"
+            captured_second_output, captured_output,
+            "cuda_graph_decode's second request must match the first captured request's greedy output"
+        );
+        drop(captured_runtime);
+
+        let paged_only_strategy = HardwareStrategy {
+            paged_attention: true,
+            ..Default::default()
+        };
+        let paged_only_runtime =
+            CandleLlmRuntime::try_load("tiny", &dir, "cuda", &paged_only_strategy)
+                .expect("the checkpoint must load with paged_attention alone")
+                .expect("tiny fixture should select the native Candle runtime");
+        let paged_only_output = paged_only_runtime
+            .generate(&[request])
+            .expect("paged-attention generation must run a real decode on the cuda device");
+        assert_eq!(
+            captured_output, paged_only_output,
+            "cuda_graph_decode's captured/replayed decode must match the non-captured paged-attention path's greedy output for the same prompt"
         );
         let _ = fs::remove_dir_all(dir);
     }

--- a/core-host/src/ai_inference/candle_llm_runtime.rs
+++ b/core-host/src/ai_inference/candle_llm_runtime.rs
@@ -1647,18 +1647,20 @@ impl CandleLlmRuntime {
             && strategy.distribution_mode == GpuDistribution::Single;
 
         // paged_attention needs that same Llama+CUDA baseline — the paged
-        // flash-attn kernel is CUDA-only — plus an actual non-`cpu` request.
-        // `load_safetensors` only wires `cache.set_paged_kv` for that exact
-        // combination (see `wire-paged-attention-decode-path`'s design.md),
-        // so every other architecture/build/device combination still fails
-        // closed here.
-        let paged_attention_supported = single_device_cuda_supported && requested_device != "cpu";
+        // flash-attn kernel is CUDA-only — plus a Safetensors checkpoint and
+        // an actual non-`cpu` request. `load_safetensors` is the only loader
+        // that wires `cache.set_paged_kv`; GGUF uses its quantized CPU loader.
+        // Every other architecture/format/build/device combination therefore
+        // fails closed here instead of silently running the contiguous path.
+        let paged_attention_supported = single_device_cuda_supported
+            && format == ModelFormat::Safetensors
+            && requested_device != "cpu";
         if strategy.paged_attention && !paged_attention_supported {
             return Err(CandleLlmError::UnsupportedModel {
                 alias: alias.to_owned(),
                 path: root.to_path_buf(),
                 detail:
-                    "paged_attention requires Tachyon's block allocator and per-sequence block table to be wired to candle_flash_attn::flash_attn_varlen_paged_windowed, and is only available for a Llama checkpoint on a CUDA device"
+                    "paged_attention requires a Safetensors Llama checkpoint on a CUDA device because only that loader wires Tachyon's block allocator and per-sequence block table to candle_flash_attn::flash_attn_varlen_paged_windowed"
                         .to_owned(),
             });
         }
@@ -1707,7 +1709,7 @@ impl CandleLlmRuntime {
                     alias: alias.to_owned(),
                     path: root.to_path_buf(),
                     detail:
-                        "cuda_graph_decode requires Tachyon's steady-state GPU decode loop to capture fixed-shape operations through candle_core::CudaGraph, and is only available for a Llama checkpoint on a CUDA device"
+                    "cuda_graph_decode requires a Safetensors Llama checkpoint on a CUDA device because it captures Tachyon's paged, steady-state GPU decode loop through candle_core::CudaGraph"
                             .to_owned(),
                 });
             }
@@ -7181,13 +7183,37 @@ mod tests {
             "cuda_graph_decode's captured/replayed decode must match the non-captured paged-attention path's greedy output for the same prompt"
         );
 
-        // A *second*, independent request against the same already-loaded
-        // runtime is a known, still-unresolved limitation — see design.md's
-        // "Known limitation" note and astorise/candle#17 (reopened: the
-        // fork's first fix attempt, verified against its own simpler
-        // regression test, did not resolve our real-world scenario — a
-        // captured multi-layer Llama::forward, not a single elementwise op —
-        // so this assertion is deliberately not restored yet).
+        let captured_second_output = captured_runtime
+            .generate(&[request])
+            .expect("cuda_graph_decode must support a second independent request");
+        assert_eq!(
+            captured_second_output, paged_only_output,
+            "cuda_graph_decode's second request must match the non-captured paged-attention path's greedy output"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(feature = "candle-cuda")]
+    #[test]
+    fn cuda_graph_decode_strategy_is_rejected_for_gguf() {
+        let (runtime, dir) = load_gguf_fixture("cuda-graph-gguf-reject");
+        drop(runtime);
+        let strategy = HardwareStrategy {
+            paged_attention: true,
+            cuda_graph_decode: true,
+            ..Default::default()
+        };
+        let error = CandleLlmRuntime::try_load("tiny-gguf", &dir, "cuda", &strategy)
+            .expect_err("cuda_graph_decode must not silently load GGUF on CPU");
+        match error {
+            CandleLlmError::UnsupportedModel { detail, .. } => {
+                assert!(
+                    detail.contains("Safetensors Llama checkpoint"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected UnsupportedModel, got {other:?}"),
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -44,5 +44,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/apache/arrow-rs-object-store.git",
     "https://github.com/astorise/candle",
+    "https://github.com/astorise/cudarc",
     "https://github.com/ebarnard/rust-plist.git",
 ]


### PR DESCRIPTION
## Changes\n- reject GGUF for paged attention and CUDA Graph decode instead of allowing a CPU-only load path\n- restore the captured runtime second-request regression assertion against Candle tachyon-v0.11.0-8\n- run both CUDA Graph rejection cases in cuda-quality\n\n## Validation\n- cargo fmt --check\n- cargo test -p core-host --bin core-host --features ai-inference gguf_greedy_decode_is_deterministic -- --nocapture\n- cargo test -p core-host --bin core-host --features ai-inference cuda_graph_decode_strategy_is_rejected_until_gpu_decode_is_wired -- --nocapture\n\nThe CUDA-specific GGUF rejection and second-request capture/replay proof run on the GPU runner.