### PR TITLE
feat(ui): add configurable local error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,36 @@ After setup:
 cd tachyon-ui && npm run tauri dev
 ```
 
+### Tachyon UI logging
+
+Tachyon UI writes failed backend invocations, uncaught frontend errors, and
+fatal application errors to a structured JSON Lines log. On first launch it
+creates the configuration file in its local application-data directory:
+
+- Windows: `%LOCALAPPDATA%\com.tachyonmesh.ui\tachyon-ui.config.json`
+- Linux: `$XDG_DATA_HOME/com.tachyonmesh.ui/tachyon-ui.config.json` or the
+  platform local-data equivalent used by Tauri
+
+Default configuration:
+
+```json
+{
+  "schemaVersion": 1,
+  "logging": {
+    "level": "info",
+    "file": "logs/tachyon-ui.jsonl",
+    "maxFileBytes": 5242880,
+    "retainedFiles": 5
+  }
+}
+```
+
+`logging.level` accepts `trace`, `debug`, `info`, `warn`, `error`, or `off`.
+The file path is relative to the application-data directory; log rotation
+produces suffixes such as `.1` and `.2`. Configuration changes are loaded on
+the next application start. Invocation parameters are intentionally excluded
+from log records because they may contain credentials or tokens.
+
 ---
 
 ### Path C — Worker / Data-Plane Node (Build from Source)

--- a/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/design.md
+++ b/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/design.md
@@ -1,0 +1,154 @@
+## Context
+
+Tachyon-UI is a Tauri desktop application with a Rust command layer and a
+TypeScript Web Components frontend. Prior to this change, command failures and
+frontend exceptions were either shown to the operator or absorbed by retry and
+optional-load flows, with no local file available for post-incident diagnosis.
+
+The application already persists security-sensitive state in Stronghold and
+passes secrets through IPC operations such as credential saving, signup,
+step-up MFA, and certificate configuration. Desktop diagnostics therefore need
+to be local and useful while explicitly avoiding the persistence of command
+arguments. This concern is distinct from the existing asynchronous guest
+stdout/stderr logging capability.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist desktop startup, fatal, failed IPC, event-listener, and uncaught
+  frontend errors in an operator-accessible local journal.
+- Provide a configuration file format that can accept future application
+  settings in addition to logging configuration.
+- Bound disk usage through level filtering and file rotation.
+- Preserve the existing UI networking behavior while capturing errors that the
+  UI intentionally handles or suppresses.
+- Prevent IPC payloads that can contain secrets from being copied into log
+  records.
+
+**Non-Goals:**
+
+- Capture guest stdout/stderr or replace the host/system FaaS telemetry
+  pipeline.
+- Ship local UI logs to a server or expose them through a new mesh API.
+- Store full frontend stacks, IPC arguments, response bodies, or Stronghold
+  records in the desktop journal.
+- Provide an in-app settings screen or hot reload for configuration changes.
+
+## Decisions
+
+### D1 - Use a versioned JSON application configuration in local app data
+
+On startup, the Rust backend loads or creates
+`tachyon-ui.config.json` beneath Tauri's `app_local_data_dir()`. The initial
+schema is:
+
+```json
+{
+  "schemaVersion": 1,
+  "logging": {
+    "level": "info",
+    "file": "logs/tachyon-ui.jsonl",
+    "maxFileBytes": 5242880,
+    "retainedFiles": 5
+  }
+}
+```
+
+JSON is already supported by the crate, is operator-readable, and permits
+future top-level settings without changing the storage mechanism. The
+`schemaVersion` field permits explicit migrations later. The log path must be
+relative to application data, the maximum file size must be at least 1024
+bytes, and retained rotated files are limited to 1 through 20.
+
+Alternative considered: TOML. It is suitable for hand editing but would add a
+parser dependency and provide no advantage for the current structured settings
+or existing JSON tooling.
+
+### D2 - Write newline-delimited JSON locally with bounded rotation
+
+`AppLogger` writes one JSON object per line containing `timestampUnixMs`,
+`level`, `source`, and `message`. Severity is filtered using the configured
+minimum level (`trace`, `debug`, `info`, `warn`, `error`, or `off`). When an
+append would exceed `maxFileBytes`, the writer rotates the file into numbered
+suffixes, retaining at most `retainedFiles` prior files.
+
+A small Rust-owned writer avoids adding a logging plugin and keeps the file
+schema, validation, and security boundary explicit. Synchronous writes are
+acceptable here because the recorded events are desktop control-plane errors,
+not request-path workload log streams.
+
+Alternative considered: reuse the guest asynchronous logging system. That
+would incorrectly mix UI workstation diagnostics with mesh workload telemetry
+and would fail when the UI cannot reach the mesh.
+
+### D3 - Capture frontend failures through a redacted internal Tauri command
+
+The Rust backend exposes `log_frontend_event`, which accepts only log level,
+source, and message. `appLogger.ts` invokes this command in a fire-and-forget
+path for frontend errors and installs handlers for `window.error` and
+`unhandledrejection`.
+
+The existing `network.ts` flow logs in its `catch` paths without replacing its
+raw invocation promise chain, preserving component microtask timing and retry
+semantics. Production call sites that previously bypassed that network wrapper
+use `loggedInvoke`, including MFA, topology, and scope-controller operations.
+Listener-registration failures in `main.ts` are also logged.
+
+### D4 - Keep the desktop logging payload free of IPC arguments
+
+Neither `loggedInvoke` nor `network.ts` sends command arguments to
+`log_frontend_event`. The log event records the failed command name as a source
+label and the returned error message only. Source labels and messages are
+bounded in length before persistence.
+
+This protects credentials, enrollment tokens, TOTP codes, certificates, and
+configuration payloads carried by commands. It also means that detailed
+payload diagnosis must use explicit operator reproduction or separately
+approved diagnostic work, rather than silently increasing log sensitivity.
+
+### D5 - Register a backend logger before desktop operations that can fail
+
+During Tauri setup, configuration is loaded, the logger is created and
+registered globally, and a startup event is written before Stronghold and
+plugin setup proceed. Once registered, a fatal error returned by the Tauri
+runtime is appended through the global logger before process exit.
+
+Errors that prevent the configuration file or log writer itself from being
+initialized remain visible through the process error path rather than being
+recursively written to an unavailable logger.
+
+## Risks / Trade-offs
+
+- **[Risk] A backend-provided error message contains sensitive text**:
+  invocation payloads are never logged, but upstream error formatting must
+  continue to avoid echoing submitted secrets. -> Mitigation: retain the
+  payload-exclusion test and add message-redaction rules if backend contracts
+  later expose sensitive error text.
+- **[Risk] Local disk failures prevent writing diagnostic records**:
+  permission or storage exhaustion can make the journal unavailable. ->
+  Mitigation: startup fails clearly if initial logging cannot be established;
+  fire-and-forget frontend logging never creates a recursive UI failure loop.
+- **[Risk] Very verbose levels consume local disk faster**: `trace` or `debug`
+  can generate more records during repeated retries. -> Mitigation:
+  size-based rotation and bounded retained-file count limit storage growth.
+- **[Trade-off] Configuration is read only on startup**: edits are not
+  immediately reflected. -> This avoids introducing a filesystem watcher or a
+  mutable runtime configuration service before more settings exist.
+
+## Migration Plan
+
+1. Distribute the updated Tachyon-UI desktop binary and frontend bundle.
+2. On first launch after upgrade, create the default JSON configuration and
+   `logs/` directory beneath the local application-data directory.
+3. Operators who need a different severity or retention policy edit the JSON
+   configuration and restart Tachyon-UI.
+4. Rollback is non-destructive: an earlier application build can ignore the
+   new configuration and JSONL files; operators may remove them separately if
+   local diagnostic history is no longer needed.
+
+## Open Questions
+
+- A future configuration change can decide whether to expose log settings in
+  the desktop UI; this change intentionally establishes only the file-backed
+  configuration contract.

--- a/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/proposal.md
+++ b/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Tachyon-UI currently surfaces desktop failures in the interface but does not
+persist them for later diagnosis. Operators need a local, configurable error
+journal for failures that occur before or during interaction with the mesh,
+without leaking authentication material carried by IPC requests.
+
+## What Changes
+
+- Add a desktop application configuration file, generated on first start, with
+  an extensible JSON schema and logging settings for severity, relative file
+  path, rotation size, and retained file count.
+- Add a Rust JSON Lines writer for Tachyon-UI application events, including
+  startup and fatal runtime errors, with level filtering and bounded rotation.
+- Add an internal Tauri command through which the frontend records failed IPC
+  operations, listener registration failures, uncaught JavaScript errors, and
+  unhandled promise rejections.
+- Route frontend operations that previously invoked Tauri directly through the
+  logging boundary, while retaining existing asynchronous behavior in the
+  shared network layer.
+- Exclude IPC arguments from log events so credentials, TOTP values, tokens,
+  certificates, and manifest payloads are not persisted in the error journal.
+- Document the generated configuration, log location, accepted levels, and
+  restart behavior for operators.
+
+## Capabilities
+
+### New Capabilities
+
+- `tachyon-ui-error-logging`: Local persistent desktop error journaling,
+  configurable severity and rotation, frontend-to-backend capture boundaries,
+  and secret-safe logging rules for Tachyon-UI.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `tachyon-ui/src/app_config.rs`: JSON configuration loading, defaults, and
+  validation.
+- `tachyon-ui/src/app_logging.rs`: structured JSONL writer and log rotation.
+- `tachyon-ui/src/main.rs`: logger bootstrap, frontend logging IPC command,
+  and fatal error capture.
+- `tachyon-ui/src/utils/appLogger.ts`, `tachyon-ui/src/utils/network.ts`, and
+  affected component/controller call sites: frontend error capture.
+- `tachyon-ui/src/utils/appLogger.test.ts`: verifies failed IPC operations do
+  not copy sensitive arguments into journal events.
+- `README.md`: operator documentation for configuring and locating desktop
+  logs.
+- This change does not alter guest/workload asynchronous logging, mesh API
+  contracts, or stored Stronghold credential data.

--- a/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/specs/tachyon-ui-error-logging/spec.md
+++ b/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/specs/tachyon-ui-error-logging/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Desktop error logging is configured through a versioned local application file
+Tachyon-UI SHALL load a versioned JSON configuration file named
+`tachyon-ui.config.json` from its local application-data directory and SHALL
+create a default configuration when that file does not yet exist.
+
+#### Scenario: First application launch creates default logging configuration
+- **WHEN** Tachyon-UI starts without an existing local application configuration file
+- **THEN** it creates `tachyon-ui.config.json` with `schemaVersion` set to `1`
+- **AND** it configures logging with level `info`, file `logs/tachyon-ui.jsonl`, maximum size `5242880` bytes, and `5` retained files
+
+#### Scenario: Operator changes the persisted logging settings
+- **WHEN** the operator edits valid logging settings in `tachyon-ui.config.json` and restarts Tachyon-UI
+- **THEN** the application uses the configured log level, relative log file path, maximum file size, and retained file count for the new process
+
+#### Scenario: Configuration attempts to write logs outside local application data
+- **WHEN** `logging.file` contains an absolute path or parent-directory traversal
+- **THEN** Tachyon-UI rejects the configuration during startup
+- **AND** it does not initialize a writer at the escaped path
+
+### Requirement: Desktop application log entries are structured, filtered, and bounded on disk
+Tachyon-UI SHALL persist enabled desktop application log events as JSON Lines
+records with timestamp, severity, source, and message fields, and SHALL bound
+disk usage through configured severity filtering and file rotation.
+
+#### Scenario: Enabled error event is persisted as a structured record
+- **GIVEN** the configured minimum level enables `error` records
+- **WHEN** Tachyon-UI records a desktop error event
+- **THEN** the active log file receives one JSON Lines record containing `timestampUnixMs`, `level`, `source`, and `message`
+
+#### Scenario: Event is below the configured level
+- **GIVEN** `logging.level` is `warn`
+- **WHEN** Tachyon-UI emits an `info` event
+- **THEN** the event is not appended to the active log file
+
+#### Scenario: Active log reaches its configured maximum size
+- **WHEN** appending a record would exceed `logging.maxFileBytes` for a non-empty active log
+- **THEN** Tachyon-UI rotates the active file into numbered suffix files
+- **AND** it retains no more prior log files than `logging.retainedFiles`
+
+### Requirement: Tachyon-UI records desktop failures visible to the application
+Tachyon-UI SHALL record failures from its frontend/backend boundary and
+unhandled desktop frontend execution after the logger has initialized.
+
+#### Scenario: A Tauri invocation used by the frontend fails
+- **WHEN** a Tachyon-UI frontend operation receives a rejected Tauri invocation
+- **THEN** the application submits an `error` log event identified by the failed IPC operation or workflow
+- **AND** the existing user feedback or reconnection behavior continues to run
+
+#### Scenario: A frontend exception is not handled by application logic
+- **WHEN** the webview raises a global JavaScript error or unhandled promise rejection
+- **THEN** Tachyon-UI submits an `error` log event identifying the relevant global frontend source
+
+#### Scenario: The initialized Tauri runtime exits with a fatal error
+- **WHEN** Tauri returns a fatal runtime error after the application logger has initialized
+- **THEN** Tachyon-UI writes an `error` event from source `application.fatal` before exiting
+
+### Requirement: Desktop error records do not persist IPC input payloads
+Tachyon-UI MUST NOT copy frontend IPC invocation arguments into desktop log
+events generated for command failure reporting.
+
+#### Scenario: A credential-bearing command fails
+- **GIVEN** a frontend invocation contains a password, token, TOTP code, certificate, or configuration payload
+- **WHEN** that invocation rejects and Tachyon-UI records the failure
+- **THEN** the log event contains the operation source and error message only
+- **AND** it does not contain the invocation arguments

--- a/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/tasks.md
+++ b/openspec/changes/archive/2026-05-25-tachyon-ui-error-logging/tasks.md
@@ -1,0 +1,27 @@
+## 1. Desktop Configuration And Writer
+
+- [x] 1.1 Add `tachyon-ui/src/app_config.rs` with a versioned, generated JSON configuration and logging defaults for level, relative file path, rotation size, and retention count.
+- [x] 1.2 Validate that configured log paths remain within the local application-data directory and that rotation bounds are acceptable.
+- [x] 1.3 Add `tachyon-ui/src/app_logging.rs` with JSON Lines output, severity filtering, message/source bounds, and numbered file rotation.
+- [x] 1.4 Add Rust unit tests covering default configuration creation, path traversal rejection, level filtering, and file rotation.
+
+## 2. Tauri And Frontend Error Capture
+
+- [x] 2.1 Initialize configuration and logging during Tauri setup, expose `log_frontend_event`, and record fatal runtime errors after logger startup.
+- [x] 2.2 Add `tachyon-ui/src/utils/appLogger.ts` to submit redacted frontend log events and capture global errors and unhandled promise rejections.
+- [x] 2.3 Record failures caught by the shared network workflow, including failed IPC commands, apply-and-seal execution, and bounded reconnect probes.
+- [x] 2.4 Route production Tauri call sites outside the network workflow through the logging boundary, including MFA, topology, and scope-controller flows.
+- [x] 2.5 Record mesh event-listener registration failures from the frontend bootstrap path.
+
+## 3. Secret Safety And Operator Documentation
+
+- [x] 3.1 Ensure frontend logging events omit invocation arguments that can include credentials, tokens, TOTP values, certificates, or configuration payloads.
+- [x] 3.2 Add a frontend unit test proving that a failed credential-bearing invocation logs only its source and error message.
+- [x] 3.3 Document the generated configuration file location, JSON schema, accepted log levels, rotation behavior, and restart requirement in `README.md`.
+
+## 4. Verification
+
+- [x] 4.1 Run `cargo test -p tachyon-ui` and verify all Rust configuration and logging unit tests pass.
+- [x] 4.2 Run `npm test` in `tachyon-ui` and verify the frontend suite passes, including the secret-exclusion logging test.
+- [x] 4.3 Run `npm run build` in `tachyon-ui` and verify the TypeScript and Vite production build succeeds.
+- [x] 4.4 Run `cargo fmt --check --package tachyon-ui` and `git diff --check` to verify formatting and patch hygiene.

--- a/openspec/specs/tachyon-ui-error-logging/spec.md
+++ b/openspec/specs/tachyon-ui-error-logging/spec.md
@@ -1,0 +1,70 @@
+# tachyon-ui-error-logging Specification
+
+## Purpose
+TBD - created by archiving change tachyon-ui-error-logging. Update Purpose after archive.
+## Requirements
+### Requirement: Desktop error logging is configured through a versioned local application file
+Tachyon-UI SHALL load a versioned JSON configuration file named
+`tachyon-ui.config.json` from its local application-data directory and SHALL
+create a default configuration when that file does not yet exist.
+
+#### Scenario: First application launch creates default logging configuration
+- **WHEN** Tachyon-UI starts without an existing local application configuration file
+- **THEN** it creates `tachyon-ui.config.json` with `schemaVersion` set to `1`
+- **AND** it configures logging with level `info`, file `logs/tachyon-ui.jsonl`, maximum size `5242880` bytes, and `5` retained files
+
+#### Scenario: Operator changes the persisted logging settings
+- **WHEN** the operator edits valid logging settings in `tachyon-ui.config.json` and restarts Tachyon-UI
+- **THEN** the application uses the configured log level, relative log file path, maximum file size, and retained file count for the new process
+
+#### Scenario: Configuration attempts to write logs outside local application data
+- **WHEN** `logging.file` contains an absolute path or parent-directory traversal
+- **THEN** Tachyon-UI rejects the configuration during startup
+- **AND** it does not initialize a writer at the escaped path
+
+### Requirement: Desktop application log entries are structured, filtered, and bounded on disk
+Tachyon-UI SHALL persist enabled desktop application log events as JSON Lines
+records with timestamp, severity, source, and message fields, and SHALL bound
+disk usage through configured severity filtering and file rotation.
+
+#### Scenario: Enabled error event is persisted as a structured record
+- **GIVEN** the configured minimum level enables `error` records
+- **WHEN** Tachyon-UI records a desktop error event
+- **THEN** the active log file receives one JSON Lines record containing `timestampUnixMs`, `level`, `source`, and `message`
+
+#### Scenario: Event is below the configured level
+- **GIVEN** `logging.level` is `warn`
+- **WHEN** Tachyon-UI emits an `info` event
+- **THEN** the event is not appended to the active log file
+
+#### Scenario: Active log reaches its configured maximum size
+- **WHEN** appending a record would exceed `logging.maxFileBytes` for a non-empty active log
+- **THEN** Tachyon-UI rotates the active file into numbered suffix files
+- **AND** it retains no more prior log files than `logging.retainedFiles`
+
+### Requirement: Tachyon-UI records desktop failures visible to the application
+Tachyon-UI SHALL record failures from its frontend/backend boundary and
+unhandled desktop frontend execution after the logger has initialized.
+
+#### Scenario: A Tauri invocation used by the frontend fails
+- **WHEN** a Tachyon-UI frontend operation receives a rejected Tauri invocation
+- **THEN** the application submits an `error` log event identified by the failed IPC operation or workflow
+- **AND** the existing user feedback or reconnection behavior continues to run
+
+#### Scenario: A frontend exception is not handled by application logic
+- **WHEN** the webview raises a global JavaScript error or unhandled promise rejection
+- **THEN** Tachyon-UI submits an `error` log event identifying the relevant global frontend source
+
+#### Scenario: The initialized Tauri runtime exits with a fatal error
+- **WHEN** Tauri returns a fatal runtime error after the application logger has initialized
+- **THEN** Tachyon-UI writes an `error` event from source `application.fatal` before exiting
+
+### Requirement: Desktop error records do not persist IPC input payloads
+Tachyon-UI MUST NOT copy frontend IPC invocation arguments into desktop log
+events generated for command failure reporting.
+
+#### Scenario: A credential-bearing command fails
+- **GIVEN** a frontend invocation contains a password, token, TOTP code, certificate, or configuration payload
+- **WHEN** that invocation rejects and Tachyon-UI records the failure
+- **THEN** the log event contains the operation source and error message only
+- **AND** it does not contain the invocation arguments

--- a/tachyon-ui/src/app_config.rs
+++ b/tachyon-ui/src/app_config.rs
@@ -1,0 +1,207 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) const CONFIG_FILE_NAME: &str = "tachyon-ui.config.json";
+const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct AppConfig {
+    pub(crate) schema_version: u32,
+    pub(crate) logging: LoggingConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            schema_version: CONFIG_SCHEMA_VERSION,
+            logging: LoggingConfig::default(),
+        }
+    }
+}
+
+impl AppConfig {
+    pub(crate) fn load_or_create(data_dir: &Path) -> Result<Self, String> {
+        fs::create_dir_all(data_dir).map_err(|error| {
+            format!(
+                "failed to create application data directory '{}': {error}",
+                data_dir.display()
+            )
+        })?;
+        let config_path = data_dir.join(CONFIG_FILE_NAME);
+        if !config_path.exists() {
+            let config = Self::default();
+            config.validate()?;
+            let serialized = serde_json::to_string_pretty(&config)
+                .map_err(|error| format!("failed to serialize default configuration: {error}"))?;
+            fs::write(&config_path, format!("{serialized}\n")).map_err(|error| {
+                format!(
+                    "failed to write configuration file '{}': {error}",
+                    config_path.display()
+                )
+            })?;
+            return Ok(config);
+        }
+
+        let serialized = fs::read_to_string(&config_path).map_err(|error| {
+            format!(
+                "failed to read configuration file '{}': {error}",
+                config_path.display()
+            )
+        })?;
+        let config: Self = serde_json::from_str(&serialized).map_err(|error| {
+            format!(
+                "invalid configuration file '{}': {error}",
+                config_path.display()
+            )
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.schema_version != CONFIG_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported configuration schema version {}; expected {}",
+                self.schema_version, CONFIG_SCHEMA_VERSION
+            ));
+        }
+        self.logging.validate()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct LoggingConfig {
+    pub(crate) level: LogLevel,
+    pub(crate) file: String,
+    pub(crate) max_file_bytes: u64,
+    pub(crate) retained_files: usize,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: LogLevel::Info,
+            file: "logs/tachyon-ui.jsonl".to_string(),
+            max_file_bytes: 5 * 1024 * 1024,
+            retained_files: 5,
+        }
+    }
+}
+
+impl LoggingConfig {
+    pub(crate) fn relative_file_path(&self) -> Result<PathBuf, String> {
+        let path = Path::new(self.file.trim());
+        if path.as_os_str().is_empty()
+            || path.file_name().is_none()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(
+                "logging.file must be a relative file path within application data".to_string(),
+            );
+        }
+        Ok(path.to_path_buf())
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        self.relative_file_path()?;
+        if self.max_file_bytes < 1024 {
+            return Err("logging.maxFileBytes must be at least 1024".to_string());
+        }
+        if !(1..=20).contains(&self.retained_files) {
+            return Err("logging.retainedFiles must be between 1 and 20".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Off,
+}
+
+impl LogLevel {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+            Self::Off => "off",
+        }
+    }
+
+    pub(crate) fn enables(self, event_level: Self) -> bool {
+        self != Self::Off && event_level != Self::Off && event_level.rank() >= self.rank()
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Trace => 0,
+            Self::Debug => 1,
+            Self::Info => 2,
+            Self::Warn => 3,
+            Self::Error => 4,
+            Self::Off => 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppConfig, LogLevel, CONFIG_FILE_NAME};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_directory(name: &str) -> std::path::PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "tachyon-ui-config-{name}-{}-{suffix}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn creates_extensible_default_configuration() {
+        let directory = test_directory("default");
+        let config = AppConfig::load_or_create(&directory).expect("default config should load");
+
+        assert_eq!(config.logging.level, LogLevel::Info);
+        assert!(directory.join(CONFIG_FILE_NAME).exists());
+
+        fs::remove_dir_all(directory).expect("test directory should be removed");
+    }
+
+    #[test]
+    fn rejects_log_files_outside_application_data() {
+        let directory = test_directory("path");
+        fs::create_dir_all(&directory).expect("test directory should be created");
+        fs::write(
+            directory.join(CONFIG_FILE_NAME),
+            r#"{"schemaVersion":1,"logging":{"file":"../escape.jsonl"}}"#,
+        )
+        .expect("test config should be written");
+
+        let error = AppConfig::load_or_create(&directory).expect_err("path should be rejected");
+        assert!(error.contains("relative file path"));
+
+        fs::remove_dir_all(directory).expect("test directory should be removed");
+    }
+}

--- a/tachyon-ui/src/app_logging.rs
+++ b/tachyon-ui/src/app_logging.rs
@@ -1,0 +1,246 @@
+use crate::app_config::{LogLevel, LoggingConfig};
+use serde::Deserialize;
+use serde_json::json;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_MESSAGE_CHARS: usize = 8192;
+const MAX_SOURCE_CHARS: usize = 160;
+static GLOBAL_LOGGER: OnceLock<AppLogger> = OnceLock::new();
+
+#[derive(Clone)]
+pub(crate) struct AppLogger {
+    inner: Arc<LoggerInner>,
+}
+
+struct LoggerInner {
+    minimum_level: LogLevel,
+    file_path: PathBuf,
+    max_file_bytes: u64,
+    retained_files: usize,
+    write_lock: Mutex<()>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FrontendLogPayload {
+    level: LogLevel,
+    message: String,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+impl AppLogger {
+    pub(crate) fn new(data_dir: &Path, config: &LoggingConfig) -> Result<Self, String> {
+        let file_path = data_dir.join(config.relative_file_path()?);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create log directory '{}': {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        Ok(Self {
+            inner: Arc::new(LoggerInner {
+                minimum_level: config.level,
+                file_path,
+                max_file_bytes: config.max_file_bytes,
+                retained_files: config.retained_files,
+                write_lock: Mutex::new(()),
+            }),
+        })
+    }
+
+    pub(crate) fn register_global(&self) {
+        let _ = GLOBAL_LOGGER.set(self.clone());
+    }
+
+    pub(crate) fn write_frontend(&self, payload: FrontendLogPayload) -> Result<(), String> {
+        self.write(
+            payload.level,
+            payload.source.as_deref().unwrap_or("frontend"),
+            &payload.message,
+        )
+    }
+
+    pub(crate) fn write(&self, level: LogLevel, source: &str, message: &str) -> Result<(), String> {
+        if level == LogLevel::Off {
+            return Err("off is a configuration level and cannot be emitted".to_string());
+        }
+        if !self.inner.minimum_level.enables(level) {
+            return Ok(());
+        }
+
+        let timestamp_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| format!("failed to obtain log timestamp: {error}"))?
+            .as_millis();
+        let entry = json!({
+            "timestampUnixMs": timestamp_unix_ms,
+            "level": level.as_str(),
+            "source": truncate(source, MAX_SOURCE_CHARS),
+            "message": truncate(message, MAX_MESSAGE_CHARS),
+        });
+        let mut encoded = serde_json::to_vec(&entry)
+            .map_err(|error| format!("failed to encode log entry: {error}"))?;
+        encoded.push(b'\n');
+
+        let _guard = self
+            .inner
+            .write_lock
+            .lock()
+            .map_err(|_| "failed to lock application log writer".to_string())?;
+        self.rotate_if_required(encoded.len() as u64)?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.inner.file_path)
+            .map_err(|error| {
+                format!(
+                    "failed to open log file '{}': {error}",
+                    self.inner.file_path.display()
+                )
+            })?;
+        file.write_all(&encoded).map_err(|error| {
+            format!(
+                "failed to write log file '{}': {error}",
+                self.inner.file_path.display()
+            )
+        })
+    }
+
+    fn rotate_if_required(&self, incoming_bytes: u64) -> Result<(), String> {
+        let existing_bytes = match fs::metadata(&self.inner.file_path) {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect log file '{}': {error}",
+                    self.inner.file_path.display()
+                ));
+            }
+        };
+        if existing_bytes == 0
+            || existing_bytes.saturating_add(incoming_bytes) <= self.inner.max_file_bytes
+        {
+            return Ok(());
+        }
+
+        let oldest = rotated_path(&self.inner.file_path, self.inner.retained_files);
+        if oldest.exists() {
+            fs::remove_file(&oldest).map_err(|error| {
+                format!(
+                    "failed to remove rotated log '{}': {error}",
+                    oldest.display()
+                )
+            })?;
+        }
+        for index in (1..self.inner.retained_files).rev() {
+            let source = rotated_path(&self.inner.file_path, index);
+            if source.exists() {
+                let target = rotated_path(&self.inner.file_path, index + 1);
+                fs::rename(&source, &target).map_err(|error| {
+                    format!(
+                        "failed to rotate log '{}' to '{}': {error}",
+                        source.display(),
+                        target.display()
+                    )
+                })?;
+            }
+        }
+        let first_rotation = rotated_path(&self.inner.file_path, 1);
+        fs::rename(&self.inner.file_path, &first_rotation).map_err(|error| {
+            format!(
+                "failed to rotate log '{}' to '{}': {error}",
+                self.inner.file_path.display(),
+                first_rotation.display()
+            )
+        })
+    }
+}
+
+pub(crate) fn write_global(level: LogLevel, source: &str, message: &str) {
+    if let Some(logger) = GLOBAL_LOGGER.get() {
+        let _ = logger.write(level, source, message);
+    }
+}
+
+fn truncate(value: &str, maximum_chars: usize) -> String {
+    value.chars().take(maximum_chars).collect()
+}
+
+fn rotated_path(file_path: &Path, index: usize) -> PathBuf {
+    let mut suffixed: OsString = file_path.as_os_str().to_os_string();
+    suffixed.push(format!(".{index}"));
+    PathBuf::from(suffixed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppLogger;
+    use crate::app_config::{LogLevel, LoggingConfig};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_directory(name: &str) -> std::path::PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "tachyon-ui-log-{name}-{}-{suffix}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn filters_entries_below_the_configured_level() {
+        let directory = test_directory("level");
+        let config = LoggingConfig {
+            level: LogLevel::Warn,
+            ..LoggingConfig::default()
+        };
+        let logger = AppLogger::new(&directory, &config).expect("logger should initialize");
+
+        logger
+            .write(LogLevel::Info, "test", "not retained")
+            .expect("filtered write should succeed");
+        logger
+            .write(LogLevel::Error, "test", "retained")
+            .expect("error should be written");
+        let contents =
+            fs::read_to_string(directory.join("logs/tachyon-ui.jsonl")).expect("log should exist");
+
+        assert!(!contents.contains("not retained"));
+        assert!(contents.contains("retained"));
+        fs::remove_dir_all(directory).expect("test directory should be removed");
+    }
+
+    #[test]
+    fn rotates_log_files_when_the_limit_is_reached() {
+        let directory = test_directory("rotate");
+        let config = LoggingConfig {
+            level: LogLevel::Trace,
+            max_file_bytes: 1024,
+            retained_files: 2,
+            ..LoggingConfig::default()
+        };
+        let logger = AppLogger::new(&directory, &config).expect("logger should initialize");
+        let message = "x".repeat(500);
+
+        for _ in 0..4 {
+            logger
+                .write(LogLevel::Error, "test", &message)
+                .expect("log should be written");
+        }
+
+        assert!(directory.join("logs/tachyon-ui.jsonl").exists());
+        assert!(directory.join("logs/tachyon-ui.jsonl.1").exists());
+        fs::remove_dir_all(directory).expect("test directory should be removed");
+    }
+}

--- a/tachyon-ui/src/app_logging.rs
+++ b/tachyon-ui/src/app_logging.rs
@@ -45,6 +45,7 @@ impl AppLogger {
                 )
             })?;
         }
+        prune_rotations(&file_path, config.retained_files)?;
         Ok(Self {
             inner: Arc::new(LoggerInner {
                 minimum_level: config.level,
@@ -180,9 +181,68 @@ fn rotated_path(file_path: &Path, index: usize) -> PathBuf {
     PathBuf::from(suffixed)
 }
 
+fn prune_rotations(file_path: &Path, retained_files: usize) -> Result<(), String> {
+    let Some(parent) = file_path.parent() else {
+        return Ok(());
+    };
+    let Some(file_name) = file_path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    let rotation_prefix = format!("{file_name}.");
+    let entries = fs::read_dir(parent).map_err(|error| {
+        format!(
+            "failed to inspect log directory '{}': {error}",
+            parent.display()
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to inspect an entry in log directory '{}': {error}",
+                parent.display()
+            )
+        })?;
+        let entry_name = entry.file_name();
+        let Some(suffix) = entry_name
+            .to_str()
+            .and_then(|name| name.strip_prefix(&rotation_prefix))
+        else {
+            continue;
+        };
+        let Ok(index) = suffix.parse::<usize>() else {
+            continue;
+        };
+        if index == 0 || index <= retained_files {
+            continue;
+        }
+        let entry_path = entry.path();
+        if !entry
+            .file_type()
+            .map_err(|error| {
+                format!(
+                    "failed to inspect rotated log '{}': {error}",
+                    entry_path.display()
+                )
+            })?
+            .is_file()
+        {
+            continue;
+        }
+        fs::remove_file(&entry_path).map_err(|error| {
+            format!(
+                "failed to remove rotated log '{}': {error}",
+                entry_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::AppLogger;
+    use super::{rotated_path, AppLogger};
     use crate::app_config::{LogLevel, LoggingConfig};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -241,6 +301,35 @@ mod tests {
 
         assert!(directory.join("logs/tachyon-ui.jsonl").exists());
         assert!(directory.join("logs/tachyon-ui.jsonl.1").exists());
+        fs::remove_dir_all(directory).expect("test directory should be removed");
+    }
+
+    #[test]
+    fn prunes_rotations_above_configured_retention_on_startup() {
+        let directory = test_directory("reduced-retention");
+        let log_path = directory.join("logs/tachyon-ui.jsonl");
+        fs::create_dir_all(log_path.parent().expect("log path should have a parent"))
+            .expect("log directory should be created");
+        for index in 1..=20 {
+            fs::write(rotated_path(&log_path, index), format!("rotation {index}"))
+                .expect("rotation should be created");
+        }
+        let unrelated_path = directory.join("logs/tachyon-ui.jsonl.backup");
+        fs::write(&unrelated_path, "unrelated").expect("unrelated file should be created");
+
+        let config = LoggingConfig {
+            retained_files: 5,
+            ..LoggingConfig::default()
+        };
+        let _logger = AppLogger::new(&directory, &config).expect("logger should initialize");
+
+        for index in 1..=5 {
+            assert!(rotated_path(&log_path, index).exists());
+        }
+        for index in 6..=20 {
+            assert!(!rotated_path(&log_path, index).exists());
+        }
+        assert!(unrelated_path.exists());
         fs::remove_dir_all(directory).expect("test directory should be removed");
     }
 }

--- a/tachyon-ui/src/components/domains/TachyonTopologyPanel.ts
+++ b/tachyon-ui/src/components/domains/TachyonTopologyPanel.ts
@@ -1,6 +1,6 @@
-import { invoke } from "@tauri-apps/api/core";
 import { TachyonConfigDashboard } from "../base/TachyonConfigDashboard";
 import { el } from "../../utils/dom-safe";
+import { loggedInvoke as invoke } from "../../utils/appLogger";
 import { t } from "../../utils/i18n";
 import stylesheetText from "../../style.css?inline";
 

--- a/tachyon-ui/src/components/domains/TachyonWorkloadsPanel.ts
+++ b/tachyon-ui/src/components/domains/TachyonWorkloadsPanel.ts
@@ -2,7 +2,7 @@ import { TachyonConfigDashboard } from "../base/TachyonConfigDashboard";
 import { el } from "../../utils/dom-safe";
 import { resilientInvoke } from "../../utils/network";
 import { t } from "../../utils/i18n";
-import { invoke } from "@tauri-apps/api/core";
+import { loggedInvoke as invoke } from "../../utils/appLogger";
 import { listManifestRoutes, writeRouteCanary, type ManifestRouteOption } from "../../controllers/manifestConfigController";
 
 type ImportPackageResult = {

--- a/tachyon-ui/src/components/iam/TachyonMfaPrompt.ts
+++ b/tachyon-ui/src/components/iam/TachyonMfaPrompt.ts
@@ -1,6 +1,5 @@
-import { invoke as tauriInvoke } from "@tauri-apps/api/core";
-
 import stylesheetText from "../../style.css?inline";
+import { loggedInvoke as tauriInvoke } from "../../utils/appLogger";
 import { t } from "../../utils/i18n";
 
 const mfaStylesheet = new CSSStyleSheet();

--- a/tachyon-ui/src/controllers/manifestConfigController.ts
+++ b/tachyon-ui/src/controllers/manifestConfigController.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { loggedInvoke as invoke } from "../utils/appLogger";
 
 type SealApplyOutcome = {
   success: boolean;

--- a/tachyon-ui/src/controllers/scopesController.ts
+++ b/tachyon-ui/src/controllers/scopesController.ts
@@ -1,5 +1,5 @@
-import { invoke } from "@tauri-apps/api/core";
 import type { ScopesMap } from "../types/scopes";
+import { loggedInvoke as invoke, logUiError } from "../utils/appLogger";
 
 type ManifestConfig = {
   routes?: Array<{
@@ -28,7 +28,7 @@ export async function readRouteScopes(routePath: string): Promise<{
   const config = await invoke<ManifestConfig>("get_manifest_config");
   const route = config.routes?.find((r) => r.path === routePath);
   if (!route) {
-    throw new Error(`Route '${routePath}' not found in manifest`);
+    throw logMissingRoute(routePath);
   }
   const rawScopes = route.scopes;
   if (!rawScopes || rawScopes === "allow-all") {
@@ -45,7 +45,7 @@ export async function writeRouteScopes(
   const routes = config.routes ?? [];
   const idx = routes.findIndex((r) => r.path === routePath);
   if (idx === -1) {
-    throw new Error(`Route '${routePath}' not found in manifest`);
+    throw logMissingRoute(routePath);
   }
   const updated = { ...routes[idx], scopes };
   const newConfig: ManifestConfig = {
@@ -58,4 +58,10 @@ export async function writeRouteScopes(
 export async function readScopeMetrics(): Promise<{ scopeDenialTotal: number }> {
   const metrics = await invoke<RuntimeMetrics>("get_metrics");
   return { scopeDenialTotal: metrics.scopeDenialTotal ?? 0 };
+}
+
+function logMissingRoute(routePath: string): Error {
+  const error = new Error(`Route '${routePath}' not found in manifest`);
+  logUiError("scopes.manifest", error);
+  return error;
 }

--- a/tachyon-ui/src/main.rs
+++ b/tachyon-ui/src/main.rs
@@ -3,6 +3,11 @@
     windows_subsystem = "windows"
 )]
 
+mod app_config;
+mod app_logging;
+
+use app_config::{AppConfig, LogLevel};
+use app_logging::{AppLogger, FrontendLogPayload};
 use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -990,6 +995,14 @@ fn stronghold_profile_key(data_dir: &std::path::Path) -> Result<Vec<u8>, String>
     }
 }
 
+#[tauri::command]
+fn log_frontend_event(
+    logger: tauri::State<'_, AppLogger>,
+    payload: FrontendLogPayload,
+) -> Result<(), String> {
+    logger.write_frontend(payload)
+}
+
 fn main() {
     let result = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -998,6 +1011,20 @@ fn main() {
                 .path()
                 .app_local_data_dir()
                 .map_err(|error| tauri::Error::Anyhow(error.into()))?;
+            let config = AppConfig::load_or_create(&data_dir)
+                .map_err(|error| tauri::Error::Anyhow(std::io::Error::other(error).into()))?;
+            let logger = AppLogger::new(&data_dir, &config.logging)
+                .map_err(|error| tauri::Error::Anyhow(std::io::Error::other(error).into()))?;
+            logger.register_global();
+            logger
+                .write(
+                    LogLevel::Info,
+                    "application.startup",
+                    "Tachyon UI is starting",
+                )
+                .map_err(|error| tauri::Error::Anyhow(std::io::Error::other(error).into()))?;
+            app.manage(logger);
+            app.manage(config);
             // Export the runtime workspace root so tachyon-client can resolve
             // integrity.lock without relying on the compile-time CARGO_MANIFEST_DIR.
             std::env::set_var("TACHYON_WORKSPACE_ROOT", &data_dir);
@@ -1081,11 +1108,13 @@ fn main() {
             load_custom_ca,
             clear_custom_ca,
             verify_session_totp,
-            stronghold_available
+            stronghold_available,
+            log_frontend_event
         ])
         .run(tauri::generate_context!());
 
     if let Err(error) = result {
+        app_logging::write_global(LogLevel::Error, "application.fatal", &error.to_string());
         eprintln!("Tachyon UI encountered a fatal error: {error}");
         std::process::exit(1);
     }

--- a/tachyon-ui/src/main.ts
+++ b/tachyon-ui/src/main.ts
@@ -4,6 +4,9 @@ import "./style.css";
 import "./components/iam/TachyonIAM";
 import "./components/layout/TachyonAppShell";
 import { connectionStore } from "./stores/connectionStore";
+import { installGlobalErrorLogging, logUiError } from "./utils/appLogger";
+
+installGlobalErrorLogging();
 
 document.addEventListener("DOMContentLoaded", () => {
   connectionStore.getState().setStatus("disconnected");
@@ -13,10 +16,10 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelector("tachyon-iam")?.classList.remove("hidden");
     document.querySelector("tachyon-app-shell")?.classList.add("hidden");
     connectionStore.getState().setStatus("disconnected");
-  });
+  }).catch((error) => logUiError("event.mesh-disconnect.listen", error));
 
   void listen("mesh-connect", () => {
     connectionStore.getState().resetRetry();
     connectionStore.getState().setStatus("connected");
-  });
+  }).catch((error) => logUiError("event.mesh-connect.listen", error));
 });

--- a/tachyon-ui/src/utils/appLogger.test.ts
+++ b/tachyon-ui/src/utils/appLogger.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+
+import { loggedInvoke } from "./appLogger";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("loggedInvoke", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("logs a rejected invocation without recording its arguments", async () => {
+    vi.mocked(invoke)
+      .mockRejectedValueOnce(new Error("backend failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      loggedInvoke("save_credentials", { password: "sensitive-value" }),
+    ).rejects.toThrow("backend failed");
+
+    expect(invoke).toHaveBeenNthCalledWith(2, "log_frontend_event", {
+      payload: {
+        level: "error",
+        source: "ipc.save_credentials",
+        message: "backend failed",
+      },
+    });
+    expect(JSON.stringify(vi.mocked(invoke).mock.calls[1])).not.toContain("sensitive-value");
+  });
+});

--- a/tachyon-ui/src/utils/appLogger.ts
+++ b/tachyon-ui/src/utils/appLogger.ts
@@ -1,0 +1,48 @@
+import { invoke as rawInvoke } from "@tauri-apps/api/core";
+
+export type UiLogLevel = "trace" | "debug" | "info" | "warn" | "error";
+
+const MAX_MESSAGE_CHARS = 8192;
+let globalHandlersInstalled = false;
+
+export function logUiEvent(level: UiLogLevel, source: string, message: string): void {
+  const payload = {
+    level,
+    source,
+    message: message.slice(0, MAX_MESSAGE_CHARS),
+  };
+  void rawInvoke<void>("log_frontend_event", { payload }).catch(() => undefined);
+}
+
+export function logUiError(source: string, error: unknown): void {
+  logUiEvent("error", source, errorMessage(error));
+}
+
+export async function loggedInvoke<T>(
+  command: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await rawInvoke<T>(command, args);
+  } catch (error) {
+    logUiError(`ipc.${command}`, error);
+    throw error;
+  }
+}
+
+export function installGlobalErrorLogging(): void {
+  if (globalHandlersInstalled) {
+    return;
+  }
+  globalHandlersInstalled = true;
+  window.addEventListener("error", (event) => {
+    logUiEvent("error", "window.error", event.message || errorMessage(event.error));
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    logUiError("window.unhandledrejection", event.reason);
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tachyon-ui/src/utils/network.ts
+++ b/tachyon-ui/src/utils/network.ts
@@ -1,6 +1,7 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 
 import { connectionStore } from "../stores/connectionStore";
+import { logUiError } from "./appLogger";
 import { ensureMfa } from "./authSudo";
 import { translateBackendError } from "./i18n";
 
@@ -40,6 +41,7 @@ export async function resilientInvoke<T>(command: string, args?: Record<string, 
     connectionStore.getState().setStatus("connected");
     return result;
   } catch (error) {
+    logUiError(`ipc.${command}`, error);
     connectionStore.getState().setStatus("disconnected");
     startReconnectLoop();
     const raw = error instanceof Error ? error.message : String(error);
@@ -76,7 +78,8 @@ function startReconnectLoop(): void {
         connectionStore.getState().setStatus("connected");
         reconnectLoop = null;
         return;
-      } catch {
+      } catch (error) {
+        logUiError("ipc.get_engine_status.reconnect", error);
         // Continue to next attempt.
       }
     }


### PR DESCRIPTION
## Summary

- add a versioned Tachyon UI application config with configurable log level, relative path, rotation size, and retention
- persist startup, fatal runtime, frontend, listener, reconnect, and failed IPC events as bounded JSON Lines
- keep invocation arguments out of log records so credentials, tokens, certificates, and manifest payloads are not persisted
- port the completed OpenSpec change onto the current UI architecture and document operator configuration

## Why

Desktop failures were visible in the interface but left no local diagnostic trail. This restores the completed but never merged implementation on top of current `main`, while routing newer direct Tauri call sites through the same redacted logging boundary.

## Validation

- `cargo fmt --package tachyon-ui -- --check`
- `cargo test -p tachyon-ui` (8 passed)
- `npm test` (117 passed)
- `npm run build`

## Notes

The Windows Rust link emitted existing `libsodium` PDB/runtime warnings, but compilation and all tests completed successfully.