### PR TITLE
feat(ai-inference): enable parallel Llama FlashAttention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "blake3",
  "bytes",
  "candle-core",
+ "candle-flash-attn",
  "candle-flashinfer-kernels",
  "candle-nn",
  "candle-onnx",

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -78,6 +78,7 @@ axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
 candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
+candle-flash-attn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
 candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true, default-features = false }
 candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }
 candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-10", version = "0.11.0", optional = true }

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -44,10 +44,11 @@ candle-cuda = [
     # Compiles in candle-transformers' paged-attention call site (the
     # cache.set_paged_kv/paged_kv seam added for hardware_strategy.paged_attention);
     # gated behind this feature because it pulls in the CUDA-only
-    # candle-flash-attn crate. Does not change runtime behavior on its own —
-    # the model only takes the paged path when the host attaches a
-    # PagedKvCache via cache.set_paged_kv.
+    # candle-flash-attn crate. Parallel Llama engines use the fused kernel for
+    # replicated attention; single-device Llama only takes the paged path when
+    # the host attaches a PagedKvCache via cache.set_paged_kv.
     "candle-transformers/flash-attn",
+    "dep:candle-flash-attn",
     "dep:cudarc",
     "dep:nvml-wrapper",
 ]
@@ -77,6 +78,7 @@ axum = "0.8"
 blake3 = "1.5"
 bytes = "1.5"
 candle-core = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
+candle-flash-attn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
 candle-flashinfer-kernels = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true, default-features = false }
 candle-nn = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }
 candle-onnx = { git = "https://github.com/astorise/candle", tag = "tachyon-v0.11.0-8", version = "0.11.0", optional = true }

--- a/core-host/src/ai_inference/candle_llm_runtime.rs
+++ b/core-host/src/ai_inference/candle_llm_runtime.rs
@@ -72,6 +72,11 @@ struct MixtralConfigJson {
     num_local_experts: usize,
 }
 
+#[cfg(feature = "candle-cuda")]
+const PARALLEL_LLAMA_USE_FLASH_ATTN: bool = true;
+#[cfg(not(feature = "candle-cuda"))]
+const PARALLEL_LLAMA_USE_FLASH_ATTN: bool = false;
+
 const CONFIG_JSON: &str = "config.json";
 const TOKENIZER_JSON: &str = "tokenizer.json";
 /// Hugging Face tokenizer settings; carries the `chat_template` (Jinja2) and the
@@ -2481,7 +2486,7 @@ impl CandleLlmRuntime {
             });
         }
         Ok(MixtralConfigJson {
-            config: raw.base.into_config(false),
+            config: raw.base.into_config(PARALLEL_LLAMA_USE_FLASH_ATTN),
             num_local_experts: raw.num_local_experts,
         })
     }
@@ -2522,7 +2527,7 @@ impl CandleLlmRuntime {
                 detail: error.to_string(),
             }
         })?;
-        Ok(llama_config.into_config(false))
+        Ok(llama_config.into_config(PARALLEL_LLAMA_USE_FLASH_ATTN))
     }
 
     /// Buffered generation: run the decode and return the full UTF-8 output. A

--- a/core-host/src/ai_inference/tensor_parallel_llama.rs
+++ b/core-host/src/ai_inference/tensor_parallel_llama.rs
@@ -126,8 +126,9 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> CandleResult<T
 
 /// Replicated (unsharded) causal self-attention, run entirely on the
 /// "primary" device. Identical math to upstream
-/// `candle_transformers::models::llama::CausalSelfAttention::forward`, minus
-/// the `flash-attn` feature path (not enabled by this crate).
+/// `candle_transformers::models::llama::CausalSelfAttention::forward`, with
+/// the Flash Attention path enabled by `core-host/candle-cuda` on CUDA tensors
+/// (F32 activations are narrowed to F16 for the fused kernel).
 ///
 /// `pub(crate)` (rather than module-private) so `expert_parallel_llama.rs`
 /// can build MoE blocks that reuse this exact attention implementation
@@ -140,7 +141,19 @@ pub(crate) struct ReplicatedAttention {
     num_attention_heads: usize,
     num_key_value_heads: usize,
     head_dim: usize,
+    use_flash_attn: bool,
     max_position_embeddings: usize,
+}
+
+#[cfg(feature = "candle-cuda")]
+fn flash_attn(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    softmax_scale: f32,
+    causal: bool,
+) -> CandleResult<Tensor> {
+    candle_flash_attn::flash_attn(q, k, v, softmax_scale, causal)
 }
 
 impl ReplicatedAttention {
@@ -156,6 +169,7 @@ impl ReplicatedAttention {
             num_attention_heads: cfg.num_attention_heads,
             num_key_value_heads: cfg.num_key_value_heads,
             head_dim: cfg.hidden_size / cfg.num_attention_heads,
+            use_flash_attn: cfg.use_flash_attn,
             max_position_embeddings: cfg.max_position_embeddings,
         })
     }
@@ -170,6 +184,22 @@ impl ReplicatedAttention {
         let cos = cache.cos.narrow(0, index_pos, seq_len)?;
         let sin = cache.sin.narrow(0, index_pos, seq_len)?;
         candle_nn::rotary_emb::rope(x, &cos, &sin)
+    }
+
+    fn flash_attn_dtype(&self, q: &Tensor, k: &Tensor, v: &Tensor) -> Option<DType> {
+        if !self.use_flash_attn
+            || !cfg!(feature = "candle-cuda")
+            || q.device().is_cpu()
+            || q.dtype() != k.dtype()
+            || q.dtype() != v.dtype()
+        {
+            return None;
+        }
+        match q.dtype() {
+            DType::F16 | DType::BF16 => Some(q.dtype()),
+            DType::F32 => Some(DType::F16),
+            _ => None,
+        }
     }
 
     pub(crate) fn forward(
@@ -230,19 +260,38 @@ impl ReplicatedAttention {
         let k = repeat_kv(k, self.num_attention_heads / self.num_key_value_heads)?;
         let v = repeat_kv(v, self.num_attention_heads / self.num_key_value_heads)?;
 
-        let in_dtype = q.dtype();
-        let q = q.to_dtype(DType::F32)?;
-        let k = k.to_dtype(DType::F32)?;
-        let v = v.to_dtype(DType::F32)?;
-        let att = (q.matmul(&k.t()?)? / (self.head_dim as f64).sqrt())?;
-        let att = if seq_len == 1 {
-            att
+        let y = if let Some(flash_dtype) = self.flash_attn_dtype(&q, &k, &v) {
+            #[cfg(feature = "candle-cuda")]
+            {
+                let in_dtype = q.dtype();
+                let q = q.to_dtype(flash_dtype)?.transpose(1, 2)?;
+                let k = k.to_dtype(flash_dtype)?.transpose(1, 2)?;
+                let v = v.to_dtype(flash_dtype)?.transpose(1, 2)?;
+                let softmax_scale = 1f32 / (self.head_dim as f32).sqrt();
+                flash_attn(&q, &k, &v, softmax_scale, seq_len > 1)?
+                    .transpose(1, 2)?
+                    .to_dtype(in_dtype)?
+            }
+            #[cfg(not(feature = "candle-cuda"))]
+            {
+                let _ = flash_dtype;
+                unreachable!("flash_attn_dtype is None without core-host/candle-cuda")
+            }
         } else {
-            let mask = cache.mask(seq_len, index_pos)?.broadcast_as(att.shape())?;
-            masked_fill(&att, &mask, f32::NEG_INFINITY)?
+            let in_dtype = q.dtype();
+            let q = q.to_dtype(DType::F32)?;
+            let k = k.to_dtype(DType::F32)?;
+            let v = v.to_dtype(DType::F32)?;
+            let att = (q.matmul(&k.t()?)? / (self.head_dim as f64).sqrt())?;
+            let att = if seq_len == 1 {
+                att
+            } else {
+                let mask = cache.mask(seq_len, index_pos)?.broadcast_as(att.shape())?;
+                masked_fill(&att, &mask, f32::NEG_INFINITY)?
+            };
+            let att = candle_nn::ops::softmax_last_dim(&att)?;
+            att.matmul(&v.contiguous()?)?.to_dtype(in_dtype)?
         };
-        let att = candle_nn::ops::softmax_last_dim(&att)?;
-        let y = att.matmul(&v.contiguous()?)?.to_dtype(in_dtype)?;
         let y = y.transpose(1, 2)?.reshape(&[b_sz, seq_len, hidden_size])?;
         self.o_proj.forward(&y)
     }
@@ -456,6 +505,48 @@ mod tests {
         .unwrap();
         let dense_model = DenseLlama::load(dense_vb, &config).unwrap();
         let mut dense_cache = DenseCache::new(false, DType::F32, &config, &dense_device).unwrap();
+
+        let tp_devices = vec![Device::Cpu, Device::Cpu];
+        let tp_vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&weight_paths, DType::F32, &tp_devices[0])
+        }
+        .unwrap();
+        let tp_model = TensorParallelLlama::load(tp_vb, &config, &tp_devices).unwrap();
+        let mut tp_cache =
+            TensorParallelCache::new(false, DType::F32, &config, &tp_devices[0]).unwrap();
+
+        let input = Tensor::from_vec(vec![1u32, 2, 3], (1, 3), &dense_device).unwrap();
+
+        let dense_logits = dense_model.forward(&input, 0, &mut dense_cache).unwrap();
+        let tp_logits = tp_model.forward(&input, 0, &mut tp_cache).unwrap();
+
+        let dense_logits: Vec<f32> = dense_logits.flatten_all().unwrap().to_vec1().unwrap();
+        let tp_logits: Vec<f32> = tp_logits.flatten_all().unwrap().to_vec1().unwrap();
+        assert_eq!(dense_logits.len(), tp_logits.len());
+        for (a, b) in dense_logits.iter().zip(tp_logits.iter()) {
+            assert!((a - b).abs() < 1e-3, "{a} != {b}");
+        }
+    }
+
+    #[test]
+    fn tensor_parallel_llama_cuda_flash_attn_flag_keeps_naive_fallback_on_cpu_f32() {
+        let dir = tempfile::tempdir().unwrap();
+        write_tachyon_tiny_fixture(dir.path()).unwrap();
+        let mut config = load_config(dir.path());
+        config.use_flash_attn = true;
+
+        let weight_paths = vec![dir.path().join("model.safetensors")];
+
+        let mut dense_config = config.clone();
+        dense_config.use_flash_attn = false;
+        let dense_device = Device::Cpu;
+        let dense_vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&weight_paths, DType::F32, &dense_device)
+        }
+        .unwrap();
+        let dense_model = DenseLlama::load(dense_vb, &dense_config).unwrap();
+        let mut dense_cache =
+            DenseCache::new(false, DType::F32, &dense_config, &dense_device).unwrap();
 
         let tp_devices = vec![Device::Cpu, Device::Cpu];
         let tp_vb = unsafe {

--- a/openspec/specs/ai-inference/spec.md
+++ b/openspec/specs/ai-inference/spec.md
@@ -453,6 +453,22 @@ When a model deployment is configured with `hardware_strategy.distribution_mode:
 - **THEN** the runtime performs the existing host-staged manual sum across devices
 - **AND** the result is unchanged from the pre-existing behavior, with no regression in any CPU-only test
 
+### Requirement: Parallel Llama attention MUST use Flash Attention when compiled for CUDA
+When the runtime is built with the `candle-cuda` Cargo feature, tensor-, pipeline-, and expert-parallel Llama-family engines SHALL enable Candle's Flash Attention kernel for replicated causal self-attention on CUDA tensors while preserving the existing naïve matmul/softmax attention as the fallback for CPU tensors and unsupported dtypes.
+
+#### Scenario: Flash Attention is selected for CUDA parallel attention
+- **GIVEN** the runtime is built with the `candle-cuda` feature
+- **AND** a tensor-, pipeline-, or expert-parallel Llama-family deployment runs replicated attention on CUDA tensors
+- **WHEN** `ReplicatedAttention::forward` computes causal self-attention
+- **THEN** the runtime dispatches through `candle-flash-attn`
+- **AND** F32 activations are narrowed to F16 for the fused kernel and converted back to the original dtype before the output projection
+
+#### Scenario: Naïve attention remains the fallback outside CUDA Flash Attention support
+- **GIVEN** the runtime is built without the `candle-cuda` feature, or attention runs on CPU tensors, or the tensor dtype is unsupported by the fused kernel
+- **WHEN** `ReplicatedAttention::forward` computes causal self-attention
+- **THEN** the runtime uses the existing matmul, causal-mask, softmax, and value-projection path
+- **AND** CPU/F32 parallel Llama tests remain numerically equivalent to the dense reference path
+
 ### Requirement: The runtime MUST execute pipeline-parallel inference across multiple nodes
 When a model deployment is configured with `hardware_strategy.distribution_mode: pipeline_parallelism`, the runtime SHALL assign contiguous layer ranges to distinct nodes/GPUs, SHALL stream activations between pipeline stages over a point-to-point transport implementing `StageTransport`, and SHALL support full autoregressive generation (prefill followed by an arbitrary number of decode steps), not prefill alone.
 


### PR DESCRIPTION
## Summary

- enable Candle FlashAttention for replicated attention in tensor-, pipeline-, and expert-parallel Llama engines on CUDA
- reuse the existing `candle-cuda` feature and current `tachyon-v0.11.0-8` Candle tag instead of restoring the obsolete standalone feature from the original branch
- narrow F32 activations to F16 for the fused kernel, restore the original dtype afterward, and preserve the naive CPU/unsupported-dtype fallback
- restore the OpenSpec contract originally completed for issue #243 but never merged

## Why

Issue #243 was closed against commit `070e11b` on `codex/archive-completed-openspec-changes`, after that branch's PR had already merged. The implementation therefore never reached `main`, and parallel Llama attention still uses the naive matmul/softmax path even though the CUDA kernel is already available in the pinned Candle fork.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p core-host --features ai-inference`
- `cargo test -p core-host --features ai-inference tensor_parallel_llama -- --nocapture` (4 passed)
- `cargo clippy -p core-host --features ai-inference --all-targets -- -D warnings -D clippy::unwrap_used`
- `openspec validate --specs --strict` (139 passed)

## Remaining proof

The PR stays draft until the `cuda-quality` lane confirms compilation and execution on a real CUDA runner. The local Windows environment cannot execute `candle-flash-attn`.