### PR TITLE
fix(deps): migrate rustcrypto next-gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -453,6 +453,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -1606,6 +1612,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1741,7 +1763,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.2",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1921,9 +1960,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1943,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2096,7 +2146,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2254,12 +2304,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.2",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2268,21 +2333,31 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2293,8 +2368,8 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "subtle",
@@ -2313,16 +2388,36 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.2",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -2410,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2486,10 +2581,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -3914,8 +4025,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4360,11 +4482,13 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -4677,7 +4801,7 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "cipher 0.4.4",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "digest 0.10.7",
  "ed25519-zebra",
  "generic-array",
@@ -4956,8 +5080,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.9",
 ]
@@ -5482,7 +5606,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5623,7 +5747,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6111,14 +6235,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6204,6 +6329,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -6300,9 +6434,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6311,8 +6445,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -6493,12 +6637,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -6654,7 +6815,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7218,6 +7379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7273,10 +7444,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -7344,7 +7515,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7412,7 +7583,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7594,10 +7765,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -7819,6 +8004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7945,6 +8140,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7987,7 +8192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8066,7 +8271,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -8342,18 +8557,18 @@ dependencies = [
 name = "system-faas-cert-manager"
 version = "1.0.0"
 dependencies = [
- "const-oid 0.9.6",
- "der",
+ "const-oid 0.10.2",
+ "der 0.8.1",
  "ed25519-dalek",
  "getrandom 0.4.3",
  "hex",
  "p256",
- "pkcs8",
- "rand_core 0.6.4",
+ "pkcs8 0.11.0",
+ "rand 0.10.2",
  "rustls",
  "serde",
  "serde_json",
- "spki",
+ "spki 0.8.0",
  "wit-bindgen 0.59.0",
  "x509-cert",
  "x509-parser",
@@ -8642,7 +8857,8 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "hex",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -8676,7 +8892,7 @@ name = "tachyon-ui"
 version = "1.0.0"
 dependencies = [
  "iota_stronghold",
- "rand_core 0.6.4",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "tachyon-client",
@@ -9070,7 +9286,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9622,7 +9838,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10815,7 +11031,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11676,6 +11892,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11764,20 +11991,22 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "zeroize",
 ]
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der",
- "spki",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "sha1 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
 ]
 
 [[package]]

--- a/core-host/Cargo.toml
+++ b/core-host/Cargo.toml
@@ -98,7 +98,7 @@ cudarc = { version = "0.19.7", default-features = false, features = ["nccl"], op
 # `candle-cuda`.
 nvml-wrapper = { version = "0.12", optional = true }
 clap = { version = "4.5", features = ["derive"] }
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 flate2 = "1"
 futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/openspec/specs/ci-security/spec.md
+++ b/openspec/specs/ci-security/spec.md
@@ -38,6 +38,13 @@ The CI workflow MUST run dependency vulnerability and policy checks before relea
 - **THEN** the repository SHALL leave the transitive dependency to upstream rather than patching unrelated crates locally
 - **AND** the dependency tree SHALL identify the blocking parent crate for follow-up
 
+#### Scenario: Coordinated RustCrypto migrations are isolated from weekly dependency groups
+- **GIVEN** RustCrypto crates share public `rand_core`, `signature`, DER, SPKI, PKCS#8, or digest trait families across Tachyon packages
+- **WHEN** Renovate proposes a next-generation RustCrypto wave that changes those trait families
+- **THEN** the affected crates SHALL be migrated and validated together in a dedicated change
+- **AND** direct randomness usage SHALL use the published OS RNG API for the selected `rand`/`rand_core` generation
+- **AND** crates blocked by an upstream trait-family mismatch, such as `rsa` remaining on an older `digest` family, SHALL stay pinned with an explanatory manifest comment until the blocking parent crate supports the newer family
+
 ### Requirement: Feature matrix validation
 The CI workflow MUST test the core host across default, no-default, all-feature, and selected feature combinations.
 

--- a/systems/system-faas-cert-manager/Cargo.toml
+++ b/systems/system-faas-cert-manager/Cargo.toml
@@ -12,47 +12,52 @@ serde_json = "1"
 wit-bindgen = "0.59"
 # Pure-Rust (wasm-safe) ed25519 signing for the cluster CA. `pkcs8`/`pem`
 # export the leaf private key as PKCS#8 PEM; `alloc` is required by both.
-ed25519-dalek = { version = "2", default-features = false, features = [
+ed25519-dalek = { version = "3", default-features = false, features = [
     "alloc",
     "pkcs8",
     "pem",
 ] }
 hex = "0.4"
-# Pure-Rust X.509 certificate building/encoding on der 0.7 / spki 0.7.
-x509-cert = { version = "0.2", default-features = false, features = ["pem"] }
-der = { version = "0.7", default-features = false, features = [
+# Pure-Rust X.509 certificate building/encoding on der 0.8 / spki 0.8.
+x509-cert = { version = "0.3", default-features = false, features = [
+    "builder",
+    "pem",
+] }
+der = { version = "0.8", default-features = false, features = [
     "alloc",
     "pem",
     "flagset",
 ] }
-spki = { version = "0.7", default-features = false, features = ["alloc"] }
+spki = { version = "0.8", default-features = false, features = ["alloc"] }
 # PKCS#8 PEM export of the P-256 leaf private key (`EncodePrivateKey`). Already
 # in the tree via ed25519-dalek / p256; named directly so both key types share
 # one trait import. `alloc` + `pem` enable `to_pkcs8_pem`.
-pkcs8 = { version = "0.10", default-features = false, features = [
+pkcs8 = { version = "0.11", default-features = false, features = [
     "alloc",
     "pem",
 ] }
-const-oid = { version = "0.9", default-features = false, features = ["db"] }
+const-oid = { version = "0.10", default-features = false, features = ["db"] }
 # Fresh leaf-key entropy. getrandom 0.2 uses the WASI backend on
 # wasm32-wasip2, so no `js` feature is needed.
 getrandom = "0.4"
 # ECDSA P-256 (NIST secp256r1) leaf keypair. P-256 is universally accepted for
 # TLS server CertificateVerify, unlike ed25519 (which narrow clients omit). This
-# 0.13.x line is pure-Rust and rides the existing der 0.7 / spki 0.7 / pkcs8 0.10
-# / sec1 0.7 stack, so it stays wasm32-wasip2-safe (no protoc / C deps). Features:
-# `ecdsa` (signing key type), `pkcs8` + `pem` (PKCS#8 PEM export of the leaf key),
-# `arithmetic` (curve arithmetic needed to derive the verifying key / SPKI).
-p256 = { version = "0.13", default-features = false, features = [
+# 0.14.x line is pure-Rust and rides the der 0.8 / spki 0.8 / pkcs8 0.11 stack,
+# so it stays wasm32-wasip2-safe (no protoc / C deps). Features:
+# `ecdsa` (signing key type), `alloc` + `pkcs8` + `pem` (PKCS#8 PEM export of
+# the leaf key), `arithmetic` (curve arithmetic needed to derive the verifying
+# key / SPKI).
+p256 = { version = "0.14", default-features = false, features = [
+    "alloc",
     "ecdsa",
     "pkcs8",
     "pem",
     "arithmetic",
 ] }
-# `OsRng` for sampling the P-256 leaf key. The `getrandom` feature backs it with
-# getrandom 0.2 (WASI on wasm32-wasip2), matching the leaf-entropy source above.
-rand_core = { version = "0.6", default-features = false, features = [
-    "getrandom",
+# `SysRng` for sampling the P-256 leaf key. In the rand 0.10 stack, the OS RNG
+# lives in `rand` behind `sys_rng`; `rand_core` carries only the shared traits.
+rand = { version = "0.10", default-features = false, features = [
+    "sys_rng",
 ] }
 
 [dev-dependencies]

--- a/systems/system-faas-cert-manager/src/lib.rs
+++ b/systems/system-faas-cert-manager/src/lib.rs
@@ -277,17 +277,17 @@ fn issue_leaf_certificate(domain: &str) -> Result<CertificateBundle, String> {
 mod cert {
     use super::{now_seconds, CertificateBundle, SigningKey};
     use const_oid::db::rfc5280::ID_KP_SERVER_AUTH;
-    use const_oid::db::rfc8410::ID_ED_25519;
     use const_oid::AssociatedOid;
-    use der::asn1::{BitString, GeneralizedTime, Ia5String, OctetString, UtcTime};
+    use der::asn1::{GeneralizedTime, Ia5String, OctetString, UtcTime};
     use der::flagset::FlagSet;
     use der::{Decode, Encode, EncodePem};
-    use ed25519_dalek::Signer;
-    use pkcs8::EncodePrivateKey;
-    use spki::{AlgorithmIdentifierOwned, EncodePublicKey, SubjectPublicKeyInfoOwned};
+    use p256::elliptic_curve::Generate;
+    use p256::pkcs8::EncodePrivateKey;
+    use spki::{EncodePublicKey, SubjectPublicKeyInfoOwned};
     use std::str::FromStr;
     use std::time::Duration;
-    use x509_cert::certificate::{Certificate, TbsCertificate, Version};
+    use x509_cert::builder::{profile::BuilderProfile, Builder, CertificateBuilder};
+    use x509_cert::certificate::{Certificate, TbsCertificate};
     use x509_cert::ext::pkix::name::GeneralName;
     use x509_cert::ext::pkix::{
         BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsages, SubjectAltName,
@@ -341,10 +341,12 @@ mod cert {
 
     /// Generate a fresh random ECDSA P-256 (NIST secp256r1) leaf keypair.
     ///
-    /// `OsRng` is getrandom-backed (WASI on wasm32-wasip2), the same entropy
+    /// `SysRng` is getrandom-backed (WASI on wasm32-wasip2), the same entropy
     /// source the cluster CA seed loading relies on.
     fn generate_leaf_key() -> p256::ecdsa::SigningKey {
-        p256::ecdsa::SigningKey::random(&mut rand_core::OsRng)
+        p256::ecdsa::SigningKey::generate_from_rng(&mut rand::rand_core::UnwrapErr(
+            rand::rngs::SysRng,
+        ))
     }
 
     /// Build the deterministic self-signed cluster-CA certificate.
@@ -389,7 +391,8 @@ mod cert {
             subject_alt_name_extension(domain)?,
         ];
         // The leaf's SPKI is the P-256 verifying key.
-        let spki = subject_public_key_info(leaf_signing_key.verifying_key())?;
+        let leaf_public_key = p256::PublicKey::from(leaf_signing_key.verifying_key());
+        let spki = subject_public_key_info(&leaf_public_key)?;
         sign_certificate(
             ca_signing_key,
             spki,
@@ -418,39 +421,42 @@ mod cert {
         validity: Validity,
         extensions: Extensions,
     ) -> Result<Certificate, String> {
-        let signature_algorithm = ed25519_algorithm_identifier();
-        let tbs_certificate = TbsCertificate {
-            version: Version::V3,
-            serial_number,
-            signature: signature_algorithm.clone(),
+        let profile = StaticProfile {
             issuer,
-            validity,
             subject,
-            subject_public_key_info,
-            issuer_unique_id: None,
-            subject_unique_id: None,
-            extensions: Some(extensions),
+            extensions,
         };
+        let builder =
+            CertificateBuilder::new(profile, serial_number, validity, subject_public_key_info)
+                .map_err(|error| format!("failed to build certificate TBS: {error}"))?;
 
-        let tbs_der = tbs_certificate
-            .to_der()
-            .map_err(|error| format!("failed to encode TBSCertificate: {error}"))?;
-        let signature = ca_signing_key.sign(&tbs_der);
-        let signature_bits = BitString::from_bytes(&signature.to_bytes())
-            .map_err(|error| format!("failed to encode certificate signature: {error}"))?;
-
-        Ok(Certificate {
-            tbs_certificate,
-            signature_algorithm,
-            signature: signature_bits,
-        })
+        builder
+            .build::<_, ed25519_dalek::Signature>(ca_signing_key)
+            .map_err(|error| format!("failed to sign certificate: {error}"))
     }
 
-    /// `AlgorithmIdentifier` for Ed25519 (OID 1.3.101.112, absent parameters).
-    fn ed25519_algorithm_identifier() -> AlgorithmIdentifierOwned {
-        AlgorithmIdentifierOwned {
-            oid: ID_ED_25519,
-            parameters: None,
+    struct StaticProfile {
+        issuer: Name,
+        subject: Name,
+        extensions: Extensions,
+    }
+
+    impl BuilderProfile for StaticProfile {
+        fn get_issuer(&self, _subject: &Name) -> Name {
+            self.issuer.clone()
+        }
+
+        fn get_subject(&self) -> Name {
+            self.subject.clone()
+        }
+
+        fn build_extensions(
+            &self,
+            _spk: spki::SubjectPublicKeyInfoRef<'_>,
+            _issuer_spk: spki::SubjectPublicKeyInfoRef<'_>,
+            _tbs: &TbsCertificate,
+        ) -> x509_cert::builder::Result<Vec<Extension>> {
+            Ok(self.extensions.clone())
         }
     }
 
@@ -483,10 +489,10 @@ mod cert {
     }
 
     fn validity(not_before_secs: u64, not_after_secs: u64) -> Result<Validity, String> {
-        Ok(Validity {
-            not_before: x509_time(not_before_secs)?,
-            not_after: x509_time(not_after_secs)?,
-        })
+        Ok(Validity::new(
+            x509_time(not_before_secs)?,
+            x509_time(not_after_secs)?,
+        ))
     }
 
     /// Encode a unix timestamp as an X.509 `Time`, using `UTCTime` through 2049

--- a/systems/system-faas-enrollment/Cargo.toml
+++ b/systems/system-faas-enrollment/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 hex = "0.4"
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/tachyon-client/Cargo.toml
+++ b/tachyon-client/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+ed25519-dalek = { version = "3", features = ["rand_core"] }
 flate2 = "1"
 hex = "0.4"
-rand_core = { version = "0.6", features = ["getrandom"] }
+rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
+rand_core = "0.10"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tachyon-client/src/lib.rs
+++ b/tachyon-client/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use ed25519_dalek::{Signer, SigningKey};
-use rand_core::OsRng;
+use rand::rngs::SysRng;
+use rand_core::UnwrapErr;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -1999,7 +2000,7 @@ async fn load_or_create_local_signing_key() -> Result<SigningKey> {
             Ok(SigningKey::from_bytes(&seed))
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let signing_key = SigningKey::generate(&mut OsRng);
+            let signing_key = SigningKey::generate(&mut UnwrapErr(SysRng));
             tokio::fs::write(&path, signing_key.to_bytes())
                 .await
                 .with_context(|| {

--- a/tachyon-ui/Cargo.toml
+++ b/tachyon-ui/Cargo.toml
@@ -15,7 +15,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-stronghold = "2"
 tokio = { version = "1", features = ["fs", "sync"] }
 wit-bindgen = "0.59"
-rand_core = { version = "0.6", features = ["getrandom"] }
+rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
 iota_stronghold = "2.1"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/tachyon-ui/src/main.rs
+++ b/tachyon-ui/src/main.rs
@@ -8,7 +8,7 @@ mod app_logging;
 
 use app_config::{AppConfig, LogLevel};
 use app_logging::{AppLogger, FrontendLogPayload};
-use rand_core::{OsRng, RngCore};
+use rand::{rngs::SysRng, TryRng};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -983,7 +983,9 @@ fn stronghold_profile_key(data_dir: &std::path::Path) -> Result<Vec<u8>, String>
                     .map_err(|error| format!("failed to create Stronghold key dir: {error}"))?;
             }
             let mut key = vec![0_u8; STRONGHOLD_PROFILE_KEY_BYTES];
-            OsRng.fill_bytes(&mut key);
+            SysRng
+                .try_fill_bytes(&mut key)
+                .map_err(|error| format!("failed to generate Stronghold profile key: {error}"))?;
             std::fs::write(&key_path, &key)
                 .map_err(|error| format!("failed to write Stronghold profile key: {error}"))?;
             Ok(key)


### PR DESCRIPTION
## Summary

- migrate the coordinated RustCrypto dependency wave across cert-manager, enrollment, tachyon-client, tachyon-ui, and core-host
- adapt cert-manager X.509 issuance to `x509-cert` 0.3 public builders and the `der`/`spki`/`pkcs8` 0.8/0.11 stack
- replace direct `rand_core` OS RNG usage with the published `rand` 0.10 `SysRng` API
- document the OpenSpec rule for coordinated RustCrypto migrations and the intentional `system-faas-node-registry` `sha2` 0.10 pin while `rsa` 0.9 remains on the older digest family

## Validation

- `cargo fmt --check`
- `openspec validate --specs --strict`
- `cargo check -p system-faas-cert-manager`
- `cargo test -p system-faas-cert-manager`
- `cargo check -p system-faas-enrollment`
- `cargo check -p tachyon-client`
- `cargo check -p tachyon-ui`
- `cargo check -p system-faas-node-registry`
- `cargo check -p core-host --no-default-features`
- `cargo check -p core-host`
- `cargo build -p system-faas-cert-manager -p system-faas-enrollment -p tachyon-client -p tachyon-ui -p system-faas-node-registry`

Fixes #362