### PR TITLE
feat(ai): add declarative scheduler manifest policy

### DIFF
--- a/core-host/src/ai_inference.rs
+++ b/core-host/src/ai_inference.rs
@@ -985,6 +985,12 @@ impl ActiveInferenceSequence {
     }
 }
 
+struct TenantFairSelection<T> {
+    selected: T,
+    tenant: String,
+    eligible_tenants: Vec<String>,
+}
+
 struct TenantFairness {
     config: SchedulerConfig,
     deficits: HashMap<String, i64>,
@@ -998,11 +1004,11 @@ impl TenantFairness {
         }
     }
 
-    fn select<'a>(
+    fn select_active<'a>(
         &mut self,
         candidates: Vec<(usize, &'a ActiveInferenceSequence)>,
         max_qos_score: u16,
-    ) -> Option<(usize, &'a ActiveInferenceSequence)> {
+    ) -> Option<TenantFairSelection<(usize, &'a ActiveInferenceSequence)>> {
         let qos_candidates = candidates
             .into_iter()
             .filter(|(_, sequence)| sequence.qos_score == max_qos_score)
@@ -1011,45 +1017,107 @@ impl TenantFairness {
             return None;
         }
 
-        let mut active_tenants = Vec::new();
-        for (_, sequence) in &qos_candidates {
-            let tenant = sequence.job.tenant_id().to_owned();
-            if !active_tenants.contains(&tenant) {
-                active_tenants.push(tenant);
+        let eligible_tenants = qos_candidates
+            .iter()
+            .map(|(_, sequence)| sequence.job.tenant_id())
+            .collect::<Vec<_>>();
+        let eligible_tenants = self.accrue_eligible_tenants(eligible_tenants);
+
+        let selected = qos_candidates.into_iter().max_by(|(_, left), (_, right)| {
+            self.deficit(left.job.tenant_id())
+                .cmp(&self.deficit(right.job.tenant_id()))
+                .then_with(|| left.priority_cmp(right))
+        })?;
+        let tenant = selected.1.job.tenant_id().to_owned();
+
+        Some(TenantFairSelection {
+            selected,
+            tenant,
+            eligible_tenants,
+        })
+    }
+
+    fn select_queued(
+        &mut self,
+        queued: &mut BinaryHeap<PrioritizedInferenceJob>,
+    ) -> Option<PrioritizedInferenceJob> {
+        let mut jobs = queued.drain().collect::<Vec<_>>();
+        let selected = self.select_queued_index(&jobs);
+
+        let selected_job = selected.map(|selection| {
+            let job = jobs.swap_remove(selection.selected);
+            self.charge(&selection.tenant, &selection.eligible_tenants, 1);
+            job
+        });
+
+        for job in jobs {
+            queued.push(job);
+        }
+
+        selected_job
+    }
+
+    fn select_queued_index(
+        &mut self,
+        jobs: &[PrioritizedInferenceJob],
+    ) -> Option<TenantFairSelection<usize>> {
+        let max_qos_score = jobs.iter().map(|job| job.qos_score).max()?;
+        let qos_candidates = jobs
+            .iter()
+            .enumerate()
+            .filter(|(_, job)| job.qos_score == max_qos_score)
+            .collect::<Vec<_>>();
+        if qos_candidates.is_empty() {
+            return None;
+        }
+
+        let eligible_tenants = qos_candidates
+            .iter()
+            .map(|(_, job)| job.job.tenant_id())
+            .collect::<Vec<_>>();
+        let eligible_tenants = self.accrue_eligible_tenants(eligible_tenants);
+
+        let selected = qos_candidates.into_iter().max_by(|(_, left), (_, right)| {
+            self.deficit(left.job.tenant_id())
+                .cmp(&self.deficit(right.job.tenant_id()))
+                .then_with(|| left.cmp(right))
+        })?;
+        let tenant = selected.1.job.tenant_id().to_owned();
+
+        Some(TenantFairSelection {
+            selected: selected.0,
+            tenant,
+            eligible_tenants,
+        })
+    }
+
+    fn accrue_eligible_tenants(&mut self, tenants: Vec<&str>) -> Vec<String> {
+        let mut eligible_tenants = Vec::new();
+        for tenant in tenants {
+            if !eligible_tenants.iter().any(|known| known == tenant) {
+                eligible_tenants.push(tenant.to_owned());
             }
         }
 
-        let total_weight = active_tenants
-            .iter()
-            .map(|tenant| self.config.tenant_weight(tenant) as i64)
-            .sum::<i64>()
-            .max(1);
-        for tenant in &active_tenants {
+        for tenant in &eligible_tenants {
             let weight = self.config.tenant_weight(tenant) as i64;
             *self.deficits.entry(tenant.clone()).or_insert(0) += weight;
         }
 
-        let selected = qos_candidates.into_iter().max_by(|(_, left), (_, right)| {
-            let left_deficit = self
-                .deficits
-                .get(left.job.tenant_id())
-                .copied()
-                .unwrap_or_default();
-            let right_deficit = self
-                .deficits
-                .get(right.job.tenant_id())
-                .copied()
-                .unwrap_or_default();
-            left_deficit
-                .cmp(&right_deficit)
-                .then_with(|| left.priority_cmp(right))
-        })?;
+        eligible_tenants
+    }
 
-        *self
-            .deficits
-            .entry(selected.1.job.tenant_id().to_owned())
-            .or_insert(0) -= total_weight;
-        Some(selected)
+    fn charge(&mut self, tenant: &str, eligible_tenants: &[String], cost: usize) {
+        let total_weight = eligible_tenants
+            .iter()
+            .map(|tenant| self.config.tenant_weight(tenant) as i64)
+            .sum::<i64>()
+            .max(1);
+        *self.deficits.entry(tenant.to_owned()).or_insert(0) -= total_weight * cost as i64;
+    }
+
+    fn deficit(&self, tenant: &str) -> i64 {
+        self.deficits.get(tenant).copied().unwrap_or_default()
     }
 }
 
@@ -1084,11 +1152,18 @@ fn run_scheduler(
 ) {
     let mut queued = BinaryHeap::new();
     let mut active = Vec::new();
+    let mut admission_fairness = TenantFairness::new(scheduler_config.clone());
     let mut tenant_fairness = TenantFairness::new(scheduler_config);
 
     loop {
         drain_ready_jobs(&mut receiver, &mut queued);
-        admit_sequences(&mut queued, &mut active, max_active_sequences, &metrics);
+        admit_sequences(
+            &mut queued,
+            &mut active,
+            max_active_sequences,
+            &metrics,
+            &mut admission_fairness,
+        );
 
         if active.is_empty() {
             let Some(job) = receiver.blocking_recv() else {
@@ -1108,9 +1183,10 @@ fn admit_sequences(
     active: &mut Vec<ActiveInferenceSequence>,
     max_active_sequences: usize,
     metrics: &SchedulerMetrics,
+    admission_fairness: &mut TenantFairness,
 ) {
     while active.len() < max_active_sequences {
-        let Some(job) = queued.pop() else {
+        let Some(job) = admission_fairness.select_queued(queued) else {
             break;
         };
         active.push(job.into());
@@ -1186,7 +1262,8 @@ fn select_active_batch(
         .iter()
         .map(|(_, sequence)| sequence.qos_score)
         .max()?;
-    let (_, first) = tenant_fairness.select(candidates, max_qos_score)?;
+    let selection = tenant_fairness.select_active(candidates, max_qos_score)?;
+    let (_, first) = selection.selected;
     let batch_key = first.batch_key();
     let mut indices = active
         .iter()
@@ -1198,6 +1275,11 @@ fn select_active_batch(
         })
         .collect::<Vec<_>>();
     indices.sort_unstable();
+    tenant_fairness.charge(
+        &selection.tenant,
+        &selection.eligible_tenants,
+        indices.len(),
+    );
     Some(indices)
 }
 
@@ -2654,6 +2736,42 @@ mod tests {
     // `fs` and `PathBuf` were used by the deleted `turboquant_ffi_match` test. The
     // replacement test builds its input in-memory so neither is needed any more.
 
+    fn mock_scheduler_model(alias: &str) -> Arc<CandleModel> {
+        Arc::new(
+            CandleModel::load_mock(&IntegrityModelBinding {
+                alias: alias.to_owned(),
+                path: format!("mock:{alias}"),
+                device: ModelDevice::Cuda,
+                qos: RouteQos::Standard,
+                dynamic: false,
+                hardware_strategy: Default::default(),
+            })
+            .expect("mock scheduler model should load"),
+        )
+    }
+
+    fn mock_inference_job(
+        model: &Arc<CandleModel>,
+        tenant: &str,
+        response_tx: mpsc::Sender<Result<Vec<u8>, anyhow::Error>>,
+    ) -> InferenceJob {
+        InferenceJob {
+            alias: model.alias.clone(),
+            adapter: Some(ResolvedLoraAdapter {
+                id: tenant.to_owned(),
+                path: PathBuf::from(format!("{tenant}.safetensors")),
+            }),
+            model: Arc::clone(model),
+            qos: model.qos,
+            input: SharedInputTensor {
+                dimensions: vec![1],
+                ty: TensorType::U8,
+                data: Arc::from(tenant.as_bytes()),
+            },
+            response_tx,
+        }
+    }
+
     #[test]
     fn runtime_preloads_model_aliases_from_config() {
         let mut route = IntegrityRoute::user("/api/guest-ai");
@@ -3216,17 +3334,7 @@ mod tests {
 
     #[test]
     fn scheduler_tenant_weights_select_weighted_share_within_same_qos() {
-        let model = Arc::new(
-            CandleModel::load_mock(&IntegrityModelBinding {
-                alias: "shared".to_owned(),
-                path: "mock:shared".to_owned(),
-                device: ModelDevice::Cuda,
-                qos: RouteQos::Standard,
-                dynamic: false,
-                hardware_strategy: Default::default(),
-            })
-            .expect("shared model should load"),
-        );
+        let model = mock_scheduler_model("shared");
         let mut tenant_fairness = TenantFairness::new(SchedulerConfig {
             tenant_weights: std::collections::BTreeMap::from([
                 ("tenant-a".to_owned(), 3),
@@ -3241,41 +3349,13 @@ mod tests {
                 qos_score: RouteQos::Standard.score(),
                 sequence: 0,
                 phase: InferenceSequencePhase::Decode,
-                job: InferenceJob {
-                    alias: model.alias.clone(),
-                    adapter: Some(ResolvedLoraAdapter {
-                        id: "tenant-a".to_owned(),
-                        path: PathBuf::from("tenant-a.safetensors"),
-                    }),
-                    model: Arc::clone(&model),
-                    qos: model.qos,
-                    input: SharedInputTensor {
-                        dimensions: vec![1],
-                        ty: TensorType::U8,
-                        data: Arc::from(b"tenant-a".as_slice()),
-                    },
-                    response_tx: tenant_a_tx,
-                },
+                job: mock_inference_job(&model, "tenant-a", tenant_a_tx),
             },
             ActiveInferenceSequence {
                 qos_score: RouteQos::Standard.score(),
                 sequence: 1,
                 phase: InferenceSequencePhase::Decode,
-                job: InferenceJob {
-                    alias: model.alias.clone(),
-                    adapter: Some(ResolvedLoraAdapter {
-                        id: "tenant-b".to_owned(),
-                        path: PathBuf::from("tenant-b.safetensors"),
-                    }),
-                    model: Arc::clone(&model),
-                    qos: model.qos,
-                    input: SharedInputTensor {
-                        dimensions: vec![1],
-                        ty: TensorType::U8,
-                        data: Arc::from(b"tenant-b".as_slice()),
-                    },
-                    response_tx: tenant_b_tx,
-                },
+                job: mock_inference_job(&model, "tenant-b", tenant_b_tx),
             },
         ];
 
@@ -3305,6 +3385,98 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn scheduler_tenant_weights_apply_during_admission() {
+        let model = mock_scheduler_model("admission-shared");
+        let metrics = SchedulerMetrics::default();
+        let mut admission_fairness = TenantFairness::new(SchedulerConfig {
+            tenant_weights: std::collections::BTreeMap::from([
+                ("tenant-high".to_owned(), 3),
+                ("tenant-low".to_owned(), 1),
+            ]),
+            ..SchedulerConfig::default()
+        });
+        let mut queued = BinaryHeap::new();
+        let mut receivers = Vec::new();
+
+        for sequence in 0..4 {
+            let (tx, rx) = mpsc::channel();
+            receivers.push(rx);
+            queued.push(PrioritizedInferenceJob::new(
+                RouteQos::Standard.score(),
+                sequence,
+                mock_inference_job(&model, "tenant-low", tx),
+            ));
+        }
+        let (high_tx, high_rx) = mpsc::channel();
+        receivers.push(high_rx);
+        queued.push(PrioritizedInferenceJob::new(
+            RouteQos::Standard.score(),
+            4,
+            mock_inference_job(&model, "tenant-high", high_tx),
+        ));
+
+        let mut active = Vec::new();
+        admit_sequences(
+            &mut queued,
+            &mut active,
+            1,
+            &metrics,
+            &mut admission_fairness,
+        );
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].job.tenant_id(), "tenant-high");
+        assert_eq!(queued.len(), 4);
+    }
+
+    #[test]
+    fn scheduler_tenant_fairness_charges_selected_batch_by_request_count() {
+        let model = mock_scheduler_model("batch-shared");
+        let mut tenant_fairness = TenantFairness::new(SchedulerConfig::default());
+        let (tenant_a_tx_1, _tenant_a_rx_1) = mpsc::channel();
+        let (tenant_a_tx_2, _tenant_a_rx_2) = mpsc::channel();
+        let (tenant_b_tx, _tenant_b_rx) = mpsc::channel();
+        let active = vec![
+            ActiveInferenceSequence {
+                qos_score: RouteQos::Standard.score(),
+                sequence: 0,
+                phase: InferenceSequencePhase::Decode,
+                job: mock_inference_job(&model, "tenant-a", tenant_a_tx_1),
+            },
+            ActiveInferenceSequence {
+                qos_score: RouteQos::Standard.score(),
+                sequence: 1,
+                phase: InferenceSequencePhase::Decode,
+                job: mock_inference_job(&model, "tenant-a", tenant_a_tx_2),
+            },
+            ActiveInferenceSequence {
+                qos_score: RouteQos::Standard.score(),
+                sequence: 2,
+                phase: InferenceSequencePhase::Decode,
+                job: mock_inference_job(&model, "tenant-b", tenant_b_tx),
+            },
+        ];
+
+        let first = select_active_batch(
+            &active,
+            InferenceSequencePhase::Decode,
+            &mut tenant_fairness,
+        )
+        .expect("first tenant should be selected");
+        assert_eq!(first.len(), 2);
+        assert_eq!(active[first[0]].job.tenant_id(), "tenant-a");
+
+        let second = select_active_batch(
+            &active,
+            InferenceSequencePhase::Decode,
+            &mut tenant_fairness,
+        )
+        .expect("second tenant should be selected");
+        assert_eq!(second.len(), 1);
+        assert_eq!(active[second[0]].job.tenant_id(), "tenant-b");
     }
 
     #[test]
@@ -3375,7 +3547,14 @@ mod tests {
             },
         ));
 
-        admit_sequences(&mut queued, &mut active, 2, &metrics);
+        let mut admission_fairness = TenantFairness::new(SchedulerConfig::default());
+        admit_sequences(
+            &mut queued,
+            &mut active,
+            2,
+            &metrics,
+            &mut admission_fairness,
+        );
         let mut tenant_fairness = TenantFairness::new(SchedulerConfig::default());
         run_continuous_step(
             AcceleratorKind::Gpu,

--- a/core-host/src/ai_inference.rs
+++ b/core-host/src/ai_inference.rs
@@ -58,7 +58,7 @@ enum TensorType {
     Fp32,
 }
 
-use crate::{IntegrityConfig, IntegrityModelBinding, RouteQos};
+use crate::{IntegrityConfig, IntegrityModelBinding, RouteQos, SchedulerConfig};
 
 const MOCK_INFERENCE_RESPONSE: &str = "MOCK_LLM_RESPONSE";
 const DEFAULT_BATCH_SIZE: usize = 32;
@@ -343,7 +343,11 @@ impl AiInferenceRuntime {
             .map(|accelerator| {
                 (
                     accelerator,
-                    AcceleratorScheduler::new(accelerator, DEFAULT_BATCH_SIZE),
+                    AcceleratorScheduler::new(
+                        accelerator,
+                        DEFAULT_BATCH_SIZE,
+                        config.scheduler.clone(),
+                    ),
                 )
             })
             .collect::<HashMap<_, _>>();
@@ -717,7 +721,11 @@ struct AcceleratorScheduler {
 }
 
 impl AcceleratorScheduler {
-    fn new(accelerator: AcceleratorKind, max_active_sequences: usize) -> Self {
+    fn new(
+        accelerator: AcceleratorKind,
+        max_active_sequences: usize,
+        scheduler_config: SchedulerConfig,
+    ) -> Self {
         let (sender, receiver) = tokio_mpsc::channel(ACCELERATOR_QUEUE_CAPACITY);
         let metrics = Arc::new(SchedulerMetrics::default());
         let worker_metrics = Arc::clone(&metrics);
@@ -725,7 +733,13 @@ impl AcceleratorScheduler {
         thread::Builder::new()
             .name(format!("tachyon-{}-dispatcher", accelerator.as_str()))
             .spawn(move || {
-                run_scheduler(accelerator, receiver, worker_metrics, max_active_sequences)
+                run_scheduler(
+                    accelerator,
+                    receiver,
+                    worker_metrics,
+                    max_active_sequences,
+                    scheduler_config,
+                )
             })
             .expect("AI inference scheduler thread should start");
 
@@ -892,6 +906,15 @@ struct InferenceJob {
     response_tx: mpsc::Sender<Result<Vec<u8>, anyhow::Error>>,
 }
 
+impl InferenceJob {
+    fn tenant_id(&self) -> &str {
+        self.adapter
+            .as_ref()
+            .map(|adapter| adapter.id.as_str())
+            .unwrap_or("default")
+    }
+}
+
 struct PrioritizedInferenceJob {
     qos_score: u16,
     sequence: usize,
@@ -962,6 +985,74 @@ impl ActiveInferenceSequence {
     }
 }
 
+struct TenantFairness {
+    config: SchedulerConfig,
+    deficits: HashMap<String, i64>,
+}
+
+impl TenantFairness {
+    fn new(config: SchedulerConfig) -> Self {
+        Self {
+            config,
+            deficits: HashMap::new(),
+        }
+    }
+
+    fn select<'a>(
+        &mut self,
+        candidates: Vec<(usize, &'a ActiveInferenceSequence)>,
+        max_qos_score: u16,
+    ) -> Option<(usize, &'a ActiveInferenceSequence)> {
+        let qos_candidates = candidates
+            .into_iter()
+            .filter(|(_, sequence)| sequence.qos_score == max_qos_score)
+            .collect::<Vec<_>>();
+        if qos_candidates.is_empty() {
+            return None;
+        }
+
+        let mut active_tenants = Vec::new();
+        for (_, sequence) in &qos_candidates {
+            let tenant = sequence.job.tenant_id().to_owned();
+            if !active_tenants.contains(&tenant) {
+                active_tenants.push(tenant);
+            }
+        }
+
+        let total_weight = active_tenants
+            .iter()
+            .map(|tenant| self.config.tenant_weight(tenant) as i64)
+            .sum::<i64>()
+            .max(1);
+        for tenant in &active_tenants {
+            let weight = self.config.tenant_weight(tenant) as i64;
+            *self.deficits.entry(tenant.clone()).or_insert(0) += weight;
+        }
+
+        let selected = qos_candidates.into_iter().max_by(|(_, left), (_, right)| {
+            let left_deficit = self
+                .deficits
+                .get(left.job.tenant_id())
+                .copied()
+                .unwrap_or_default();
+            let right_deficit = self
+                .deficits
+                .get(right.job.tenant_id())
+                .copied()
+                .unwrap_or_default();
+            left_deficit
+                .cmp(&right_deficit)
+                .then_with(|| left.priority_cmp(right))
+        })?;
+
+        *self
+            .deficits
+            .entry(selected.1.job.tenant_id().to_owned())
+            .or_insert(0) -= total_weight;
+        Some(selected)
+    }
+}
+
 impl PartialEq for PrioritizedInferenceJob {
     fn eq(&self, other: &Self) -> bool {
         self.qos_score == other.qos_score && self.sequence == other.sequence
@@ -989,9 +1080,11 @@ fn run_scheduler(
     mut receiver: tokio_mpsc::Receiver<PrioritizedInferenceJob>,
     metrics: Arc<SchedulerMetrics>,
     max_active_sequences: usize,
+    scheduler_config: SchedulerConfig,
 ) {
     let mut queued = BinaryHeap::new();
     let mut active = Vec::new();
+    let mut tenant_fairness = TenantFairness::new(scheduler_config);
 
     loop {
         drain_ready_jobs(&mut receiver, &mut queued);
@@ -1005,7 +1098,7 @@ fn run_scheduler(
             continue;
         }
 
-        run_continuous_step(accelerator, &mut active, &metrics);
+        run_continuous_step(accelerator, &mut active, &metrics, &mut tenant_fairness);
         age_waiting_jobs(&mut queued);
     }
 }
@@ -1043,8 +1136,11 @@ fn run_continuous_step(
     accelerator: AcceleratorKind,
     active: &mut Vec<ActiveInferenceSequence>,
     metrics: &SchedulerMetrics,
+    tenant_fairness: &mut TenantFairness,
 ) {
-    if let Some(indices) = select_active_batch(active, InferenceSequencePhase::Prefill) {
+    if let Some(indices) =
+        select_active_batch(active, InferenceSequencePhase::Prefill, tenant_fairness)
+    {
         let prefill_batch = indices
             .iter()
             .map(|index| active[*index].job.clone())
@@ -1056,7 +1152,9 @@ fn run_continuous_step(
         return;
     }
 
-    let Some(indices) = select_active_batch(active, InferenceSequencePhase::Decode) else {
+    let Some(indices) =
+        select_active_batch(active, InferenceSequencePhase::Decode, tenant_fairness)
+    else {
         return;
     };
     let mut decode_batch = Vec::with_capacity(indices.len());
@@ -1077,12 +1175,18 @@ fn run_continuous_step(
 fn select_active_batch(
     active: &[ActiveInferenceSequence],
     phase: InferenceSequencePhase,
+    tenant_fairness: &mut TenantFairness,
 ) -> Option<Vec<usize>> {
-    let (_, first) = active
+    let candidates = active
         .iter()
         .enumerate()
         .filter(|(_, sequence)| sequence.phase == phase)
-        .max_by(|(_, left), (_, right)| left.priority_cmp(right))?;
+        .collect::<Vec<_>>();
+    let max_qos_score = candidates
+        .iter()
+        .map(|(_, sequence)| sequence.qos_score)
+        .max()?;
+    let (_, first) = tenant_fairness.select(candidates, max_qos_score)?;
     let batch_key = first.batch_key();
     let mut indices = active
         .iter()
@@ -3111,6 +3215,99 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_tenant_weights_select_weighted_share_within_same_qos() {
+        let model = Arc::new(
+            CandleModel::load_mock(&IntegrityModelBinding {
+                alias: "shared".to_owned(),
+                path: "mock:shared".to_owned(),
+                device: ModelDevice::Cuda,
+                qos: RouteQos::Standard,
+                dynamic: false,
+                hardware_strategy: Default::default(),
+            })
+            .expect("shared model should load"),
+        );
+        let mut tenant_fairness = TenantFairness::new(SchedulerConfig {
+            tenant_weights: std::collections::BTreeMap::from([
+                ("tenant-a".to_owned(), 3),
+                ("tenant-b".to_owned(), 1),
+            ]),
+            ..SchedulerConfig::default()
+        });
+        let (tenant_a_tx, _tenant_a_rx) = mpsc::channel();
+        let (tenant_b_tx, _tenant_b_rx) = mpsc::channel();
+        let active = vec![
+            ActiveInferenceSequence {
+                qos_score: RouteQos::Standard.score(),
+                sequence: 0,
+                phase: InferenceSequencePhase::Decode,
+                job: InferenceJob {
+                    alias: model.alias.clone(),
+                    adapter: Some(ResolvedLoraAdapter {
+                        id: "tenant-a".to_owned(),
+                        path: PathBuf::from("tenant-a.safetensors"),
+                    }),
+                    model: Arc::clone(&model),
+                    qos: model.qos,
+                    input: SharedInputTensor {
+                        dimensions: vec![1],
+                        ty: TensorType::U8,
+                        data: Arc::from(b"tenant-a".as_slice()),
+                    },
+                    response_tx: tenant_a_tx,
+                },
+            },
+            ActiveInferenceSequence {
+                qos_score: RouteQos::Standard.score(),
+                sequence: 1,
+                phase: InferenceSequencePhase::Decode,
+                job: InferenceJob {
+                    alias: model.alias.clone(),
+                    adapter: Some(ResolvedLoraAdapter {
+                        id: "tenant-b".to_owned(),
+                        path: PathBuf::from("tenant-b.safetensors"),
+                    }),
+                    model: Arc::clone(&model),
+                    qos: model.qos,
+                    input: SharedInputTensor {
+                        dimensions: vec![1],
+                        ty: TensorType::U8,
+                        data: Arc::from(b"tenant-b".as_slice()),
+                    },
+                    response_tx: tenant_b_tx,
+                },
+            },
+        ];
+
+        let selected = (0..8)
+            .map(|_| {
+                let indices = select_active_batch(
+                    &active,
+                    InferenceSequencePhase::Decode,
+                    &mut tenant_fairness,
+                )
+                .expect("tenant should be selected");
+                active[indices[0]].job.tenant_id().to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            selected
+                .iter()
+                .filter(|tenant| tenant.as_str() == "tenant-a")
+                .count(),
+            6
+        );
+        assert_eq!(
+            selected
+                .iter()
+                .filter(|tenant| tenant.as_str() == "tenant-b")
+                .count(),
+            2
+        );
+    }
+
+    #[test]
     fn realtime_qos_preempts_batch_backlog_on_gpu_scheduler() {
         let batch_model = Arc::new(
             CandleModel::load_mock(&IntegrityModelBinding {
@@ -3179,8 +3376,19 @@ mod tests {
         ));
 
         admit_sequences(&mut queued, &mut active, 2, &metrics);
-        run_continuous_step(AcceleratorKind::Gpu, &mut active, &metrics);
-        run_continuous_step(AcceleratorKind::Gpu, &mut active, &metrics);
+        let mut tenant_fairness = TenantFairness::new(SchedulerConfig::default());
+        run_continuous_step(
+            AcceleratorKind::Gpu,
+            &mut active,
+            &metrics,
+            &mut tenant_fairness,
+        );
+        run_continuous_step(
+            AcceleratorKind::Gpu,
+            &mut active,
+            &metrics,
+            &mut tenant_fairness,
+        );
 
         let _ = realtime_rx
             .recv()
@@ -3190,7 +3398,12 @@ mod tests {
             batch_rx.try_recv().is_err(),
             "active batch decode should not complete before inserted realtime decode"
         );
-        run_continuous_step(AcceleratorKind::Gpu, &mut active, &metrics);
+        run_continuous_step(
+            AcceleratorKind::Gpu,
+            &mut active,
+            &metrics,
+            &mut tenant_fairness,
+        );
         let _ = batch_rx
             .recv()
             .expect("batch response should arrive")

--- a/core-host/src/host_core/domain_types.rs
+++ b/core-host/src/host_core/domain_types.rs
@@ -1010,6 +1010,78 @@ impl EnrollmentConfig {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SchedulerSpillTier {
+    #[default]
+    Ram,
+    Nvme,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+pub(crate) struct SchedulerTierPreemptible {
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) realtime: bool,
+    #[serde(default = "default_true")]
+    pub(crate) standard: bool,
+    #[serde(default = "default_true")]
+    pub(crate) batch: bool,
+}
+
+impl Default for SchedulerTierPreemptible {
+    fn default() -> Self {
+        Self {
+            realtime: false,
+            standard: true,
+            batch: true,
+        }
+    }
+}
+
+impl SchedulerTierPreemptible {
+    pub(crate) fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    #[cfg_attr(not(feature = "ai-inference"), allow(dead_code))]
+    pub(crate) fn is_preemptible(self, qos: RouteQos) -> bool {
+        match qos {
+            RouteQos::RealTime => self.realtime,
+            RouteQos::Standard => self.standard,
+            RouteQos::Batch => self.batch,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+pub(crate) struct SchedulerConfig {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) tenant_weights: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "SchedulerTierPreemptible::is_default")]
+    pub(crate) tier_preemptible: SchedulerTierPreemptible,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub(crate) spill_budget_bytes: u64,
+    #[serde(default, skip_serializing_if = "is_default_scheduler_spill_tier")]
+    pub(crate) spill_tier_max: SchedulerSpillTier,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub(crate) pinned_ram_pool_bytes: u64,
+}
+
+impl SchedulerConfig {
+    pub(crate) fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    #[cfg_attr(not(feature = "ai-inference"), allow(dead_code))]
+    pub(crate) fn tenant_weight(&self, tenant: &str) -> u32 {
+        self.tenant_weights.get(tenant).copied().unwrap_or(1)
+    }
+}
+
+pub(crate) fn is_default_scheduler_spill_tier(value: &SchedulerSpillTier) -> bool {
+    *value == SchedulerSpillTier::Ram
+}
+
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 pub(crate) struct IntegrityConfig {
     pub(crate) host_address: String,
@@ -1076,6 +1148,11 @@ pub(crate) struct IntegrityConfig {
     /// when that model is hot on the receiving node.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) kv_caches: Vec<IntegrityKvCacheConfig>,
+    /// Declarative AI scheduler policy. Defaults preserve the pre-existing
+    /// QoS-only scheduler behavior; non-default values are supplied by the
+    /// sealed manifest so core owns mechanism while operators own policy.
+    #[serde(default, skip_serializing_if = "SchedulerConfig::is_default")]
+    pub(crate) scheduler: SchedulerConfig,
     /// When `true`, manifests whose `scopes:` block is absent or resolves to
     /// `allow-all` are rejected at submission time. Default `false` — the
     /// transition from implicit allow-all to explicit scopes is operator-paced.
@@ -1109,6 +1186,7 @@ impl Default for IntegrityConfig {
             trusted_signers: Vec::new(),
             asset_versions: BTreeMap::new(),
             kv_caches: Vec::new(),
+            scheduler: SchedulerConfig::default(),
             require_scopes: false,
         }
     }

--- a/core-host/src/host_core/integrity_config.rs
+++ b/core-host/src/host_core/integrity_config.rs
@@ -932,6 +932,7 @@ pub(crate) fn validate_integrity_config(mut config: IntegrityConfig) -> Result<I
     validate_tee_requirements(&config)?;
     validate_enrollment_config(&config.enrollment)?;
     validate_kv_caches(&config)?;
+    validate_scheduler_config(&config)?;
     let route_registry = RouteRegistry::build(&config)?;
     config.resources = normalize_resources(config.resources, &config.routes, &route_registry)?;
     config.layer4 = normalize_layer4_config(config.layer4, &route_registry)?;
@@ -1026,6 +1027,66 @@ pub(crate) fn validate_kv_caches(config: &IntegrityConfig) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Validates manifest-declared scheduler policy without hard-coding tenant
+/// fairness in the runtime.
+pub(crate) fn validate_scheduler_config(config: &IntegrityConfig) -> Result<()> {
+    let mut known_tenants = BTreeSet::from(["default".to_owned()]);
+    for route in &config.routes {
+        if let Some(adapter_id) = route.adapter_id.as_deref().map(str::trim) {
+            if !adapter_id.is_empty() {
+                known_tenants.insert(adapter_id.to_owned());
+            }
+        }
+    }
+
+    for (tenant, weight) in &config.scheduler.tenant_weights {
+        let trimmed = tenant.trim();
+        if trimmed.is_empty() || !is_scheduler_tenant_id_valid(trimmed) {
+            anyhow::bail!(
+                "Integrity Validation Failed: scheduler.tenant_weights key `{tenant}` must be a non-empty tenant identifier without path separators"
+            );
+        }
+        if trimmed != tenant {
+            anyhow::bail!(
+                "Integrity Validation Failed: scheduler.tenant_weights key `{tenant}` must not contain leading or trailing whitespace"
+            );
+        }
+        if *weight == 0 {
+            anyhow::bail!(
+                "Integrity Validation Failed: scheduler.tenant_weights.`{tenant}` must be greater than zero"
+            );
+        }
+        if !known_tenants.contains(tenant) {
+            anyhow::bail!(
+                "Integrity Validation Failed: scheduler.tenant_weights references unknown tenant `{tenant}`; declare the tenant as a route `adapter_id` or use `default`"
+            );
+        }
+    }
+
+    if config.scheduler.spill_budget_bytes > 0
+        && config.scheduler.spill_tier_max == SchedulerSpillTier::Ram
+        && config.scheduler.pinned_ram_pool_bytes > 0
+        && config.scheduler.spill_budget_bytes > config.scheduler.pinned_ram_pool_bytes
+    {
+        tracing::warn!(
+            spill_budget_bytes = config.scheduler.spill_budget_bytes,
+            pinned_ram_pool_bytes = config.scheduler.pinned_ram_pool_bytes,
+            "scheduler spill budget exceeds the configured pinned RAM pool"
+        );
+    }
+
+    Ok(())
+}
+
+fn is_scheduler_tenant_id_valid(tenant: &str) -> bool {
+    !tenant.contains("..")
+        && !tenant.contains('/')
+        && !tenant.contains('\\')
+        && tenant
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '@'))
 }
 
 /// Enforces `require_scopes: true` — every route must have an explicit,

--- a/core-host/src/host_core/tests/config_validation.rs
+++ b/core-host/src/host_core/tests/config_validation.rs
@@ -55,6 +55,114 @@ fn validate_integrity_config_rejects_duplicate_routes() {
 }
 
 #[test]
+fn validate_integrity_config_accepts_scheduler_policy_for_known_tenants() {
+    let mut route = IntegrityRoute::user("/api/guest-ai");
+    route.adapter_id = Some("tenant-a".to_owned());
+    let mut config = IntegrityConfig::default_sealed();
+    config.routes = vec![route];
+    config.scheduler = SchedulerConfig {
+        tenant_weights: std::collections::BTreeMap::from([
+            ("tenant-a".to_owned(), 3),
+            ("default".to_owned(), 1),
+        ]),
+        tier_preemptible: SchedulerTierPreemptible {
+            realtime: false,
+            standard: true,
+            batch: true,
+        },
+        spill_budget_bytes: 512 * 1024 * 1024,
+        spill_tier_max: SchedulerSpillTier::Nvme,
+        pinned_ram_pool_bytes: 256 * 1024 * 1024,
+    };
+
+    let config = validate_integrity_config(config).expect("scheduler policy should validate");
+
+    assert_eq!(config.scheduler.tenant_weights["tenant-a"], 3);
+    assert!(!config
+        .scheduler
+        .tier_preemptible
+        .is_preemptible(RouteQos::RealTime));
+    assert!(config
+        .scheduler
+        .tier_preemptible
+        .is_preemptible(RouteQos::Standard));
+    assert!(config
+        .scheduler
+        .tier_preemptible
+        .is_preemptible(RouteQos::Batch));
+}
+
+#[test]
+fn manifest_schema_exposes_scheduler_config_fields() {
+    let schema = serde_json::to_value(schemars::schema_for!(IntegrityConfig))
+        .expect("IntegrityConfig schema should serialize");
+    let defs = schema
+        .get("$defs")
+        .or_else(|| schema.get("definitions"))
+        .and_then(serde_json::Value::as_object)
+        .expect("schema should expose definitions");
+    let scheduler_def = defs
+        .get("SchedulerConfig")
+        .expect("SchedulerConfig definition should be present");
+    let properties = scheduler_def["properties"]
+        .as_object()
+        .expect("SchedulerConfig properties should be an object");
+
+    for field in [
+        "tenant_weights",
+        "tier_preemptible",
+        "spill_budget_bytes",
+        "spill_tier_max",
+        "pinned_ram_pool_bytes",
+    ] {
+        assert!(
+            properties.contains_key(field),
+            "SchedulerConfig schema should expose `{field}`"
+        );
+    }
+}
+
+#[test]
+fn default_scheduler_config_serializes_out_of_default_manifest() {
+    let config = IntegrityConfig::default_sealed();
+    let value = serde_json::to_value(&config).expect("default config should serialize");
+
+    assert!(
+        value.get("scheduler").is_none(),
+        "default scheduler config should be omitted for backwards-compatible manifests"
+    );
+}
+
+#[test]
+fn validate_integrity_config_rejects_scheduler_zero_weight() {
+    let mut route = IntegrityRoute::user("/api/guest-ai");
+    route.adapter_id = Some("tenant-a".to_owned());
+    let mut config = IntegrityConfig::default_sealed();
+    config.routes = vec![route];
+    config.scheduler.tenant_weights =
+        std::collections::BTreeMap::from([("tenant-a".to_owned(), 0)]);
+
+    let error =
+        validate_integrity_config(config).expect_err("zero tenant weights must fail validation");
+
+    assert!(error.to_string().contains("must be greater than zero"));
+}
+
+#[test]
+fn validate_integrity_config_rejects_scheduler_unknown_tenant() {
+    let mut config = IntegrityConfig::default_sealed();
+    config.scheduler.tenant_weights =
+        std::collections::BTreeMap::from([("tenant-missing".to_owned(), 1)]);
+
+    let error =
+        validate_integrity_config(config).expect_err("unknown tenant weights must fail validation");
+
+    assert!(error
+        .to_string()
+        .contains("unknown tenant `tenant-missing`"));
+}
+
+#[test]
 fn validate_integrity_config_rejects_typo_in_scope_category() {
     let mut route = IntegrityRoute::user("/api/guest-example");
     route.scopes = Some(json!({ "secrest": ["db/prod/*"] }));

--- a/docs/config-exposure-audit.md
+++ b/docs/config-exposure-audit.md
@@ -20,6 +20,7 @@ through the sealed manifest path. The live schema is available from
 | `require_scopes` | Routing panel, Manifest routing controls |
 | `trusted_signers` | Identity panel, Trusted manifest signers form |
 | `telemetry_sample_rate`, `instance_pool_max_memory_bytes`, `cloud_sync_endpoint`, `batch_targets` | Routing panel, Manifest routing controls |
+| `scheduler.tenant_weights`, `scheduler.tier_preemptible`, `scheduler.spill_budget_bytes`, `scheduler.spill_tier_max`, `scheduler.pinned_ram_pool_bytes` | AI/Hardware panel, manifest schema editor |
 
 ## Manifest Only
 

--- a/openspec/specs/ai-inference/spec.md
+++ b/openspec/specs/ai-inference/spec.md
@@ -75,6 +75,20 @@ processing only the first request in the batch.
 - **AND** a backend that cannot produce a distinct output per request in the batch fails the batch
   with an error rather than silently returning fewer outputs than requests
 
+### Requirement: AI scheduler MUST apply declarative tenant fairness within QoS tiers
+The AI inference scheduler SHALL consume `IntegrityConfig.scheduler.tenant_weights` when selecting the next sequence to admit or advance on an accelerator. Tenant identity SHALL come from the request adapter/tenant id when present and SHALL fall back to `default`; the scheduler SHALL keep QoS ordering first, then apply weighted tenant fairness within the currently eligible QoS tier. With no declared tenant weights, every tenant SHALL behave as weight `1`, preserving the previous QoS-only behavior.
+
+#### Scenario: Weighted tenants share saturated decode capacity
+- **GIVEN** two saturated tenants in the same QoS tier with weights `3` and `1`
+- **WHEN** the scheduler repeatedly selects decode work for a compatible accelerator
+- **THEN** the higher-weight tenant receives approximately three quarters of the selected work over the scheduling window
+- **AND** the lower-weight tenant continues to receive work rather than being starved
+
+#### Scenario: QoS priority remains stronger than tenant weight
+- **GIVEN** a `RealTime` sequence and a `Batch` sequence are both eligible
+- **WHEN** the scheduler chooses the next step
+- **THEN** the `RealTime` sequence is selected before the `Batch` sequence even if the batch tenant has a higher declared tenant weight
+
 ### Requirement: Candle LLM prefill is chunked and configurable
 The Candle LLM runtime SHALL split prompt prefill into bounded token chunks before entering
 autoregressive decode. The default chunk size SHALL be 8192 tokens, model bindings MAY configure

--- a/openspec/specs/core-host/spec.md
+++ b/openspec/specs/core-host/spec.md
@@ -29,6 +29,26 @@ serde_json::to_string(&schema)
 - **THEN** core-host returns the generated `IntegrityConfig` JSON Schema
 - **AND** the schema exposes snake_case properties matching serde deserialization
 - **AND** it includes nested route configuration such as `targets`, `models`, `hardware_strategy`, `volumes`, `runtime`, `concurrency`, `distributed_rate_limit`, and `canary.metrics`
+- **AND** it includes the host-level `scheduler` block with `tenant_weights`, `tier_preemptible`, `spill_budget_bytes`, `spill_tier_max`, and `pinned_ram_pool_bytes`
+
+### Requirement: Manifest validation MUST cover declarative AI scheduler policy
+The integrity manifest SHALL accept a host-level `scheduler` block that declares tenant weights, QoS-tier preemptibility, spill budget, maximum spill tier, and pinned RAM pool sizing. Omitted scheduler fields SHALL deserialize to the previous scheduler behavior: no tenant-specific weighting, `RealTime` not preemptible/pageable, `Standard` and `Batch` preemptible/pageable, RAM as the maximum spill tier, and zero explicit spill/pinned-pool budget. Validation SHALL reject non-positive tenant weights and tenant keys that do not resolve to `default` or a tenant declared by route-level `adapter_id`.
+
+#### Scenario: Scheduler policy appears in the manifest schema
+- **WHEN** an operator requests `GET /admin/schema/manifest`
+- **THEN** the schema exposes `scheduler.tenant_weights`, `scheduler.tier_preemptible`, `scheduler.spill_budget_bytes`, `scheduler.spill_tier_max`, and `scheduler.pinned_ram_pool_bytes`
+- **AND** MCP host-level manifest patching can describe and patch the `scheduler` block through the generated manifest schema
+
+#### Scenario: Scheduler validation rejects unknown or zero-weight tenants
+- **WHEN** a manifest declares `scheduler.tenant_weights` with a weight of `0`
+- **THEN** validation fails before the manifest is sealed
+- **WHEN** a manifest declares a scheduler tenant that is neither `default` nor a route `adapter_id`
+- **THEN** validation fails before the manifest is sealed
+
+#### Scenario: RealTime remains non-preemptible by default
+- **WHEN** a manifest omits `scheduler.tier_preemptible`
+- **THEN** `RealTime` routes are not preemptible/pageable
+- **AND** `Standard` and `Batch` routes remain preemptible/pageable
 
 ### Requirement: The host provides an incremental body-flush streaming transport
 

--- a/tachyon-mcp/src/main.rs
+++ b/tachyon-mcp/src/main.rs
@@ -771,7 +771,7 @@ async fn handle_line(line: &str, context: &McpContext) -> Result<Option<Value>> 
                 },
                 {
                     "name": "tachyon_patch_manifest",
-                    "description": "Patch configurable host-level fields in the live manifest. Reads the current manifest, recursively merges the JSON patch object at the manifest root using JSON Merge Patch semantics: object fields merge recursively, null removes the target key, and missing keys are left unchanged. It validates the merged manifest through the node dry-run endpoint, and POSTs it when dry_run=false. Prefer dry_run=true first to preview host-level edits such as enrollment, layer4, tee_backend, trusted_signers, require_scopes, kv_caches, telemetry_sample_rate, instance_pool_max_memory_bytes, cloud_sync_endpoint, or batch_targets. The structural fields routes, config_version, and asset_versions cannot be patched here, including via null; use tachyon_patch_route for route changes.",
+                    "description": "Patch configurable host-level fields in the live manifest. Reads the current manifest, recursively merges the JSON patch object at the manifest root using JSON Merge Patch semantics: object fields merge recursively, null removes the target key, and missing keys are left unchanged. It validates the merged manifest through the node dry-run endpoint, and POSTs it when dry_run=false. Prefer dry_run=true first to preview host-level edits such as enrollment, layer4, tee_backend, trusted_signers, require_scopes, kv_caches, scheduler, telemetry_sample_rate, instance_pool_max_memory_bytes, cloud_sync_endpoint, or batch_targets. The structural fields routes, config_version, and asset_versions cannot be patched here, including via null; use tachyon_patch_route for route changes.",
                     "inputSchema": {
                         "type": "object",
                         "required": ["patch"],
@@ -2511,6 +2511,13 @@ mod tests {
         assert_eq!(
             patch_manifest["inputSchema"]["properties"]["dry_run"]["default"],
             true
+        );
+        assert!(
+            patch_manifest["description"]
+                .as_str()
+                .expect("patch_manifest description should be a string")
+                .contains("scheduler"),
+            "patch_manifest description should advertise scheduler host-level edits"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #318.

Adds a host-level `IntegrityConfig.scheduler` manifest policy for AI scheduling with tenant weights, QoS tier preemptibility, spill budget, max spill tier, and pinned RAM pool sizing. The scheduler consumes tenant weights inside the current QoS tier while preserving existing QoS priority and default behavior when the block is omitted.

## Changes

- Add serde + JsonSchema types for `scheduler` and backward-compatible defaults.
- Validate scheduler tenant weights at seal time and warn when RAM spill budget exceeds the pinned RAM pool.
- Apply weighted tenant fairness in the per-accelerator AI scheduler.
- Expose the field through manifest schema, MCP tool description, config exposure audit, and OpenSpec.
- Add unit coverage for validation, schema exposure, default serialization, MCP advertisement, and 3/1 scheduler fairness.

## Validation

- `cargo fmt --all --check`
- `cargo test -p core-host scheduler`
- `cargo test -p tachyon-mcp tools_list_includes_patch_manifest_tool`
- `cargo test -p core-host --features ai-inference scheduler_tenant_weights_select_weighted_share_within_same_qos`
- `openspec validate --all`