### PR TITLE
Fix Fortio install in bench workflow

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Install fortio
         run: |
           FORTIO_VERSION="$(curl -s https://api.github.com/repos/fortio/fortio/releases/latest | grep -oE '"tag_name": *"[^"]+"' | cut -d'"' -f4)"
-          curl -L -o fortio "https://github.com/fortio/fortio/releases/download/${FORTIO_VERSION}/fortio_linux_amd64"
-          chmod +x fortio
-          sudo mv fortio /usr/local/bin/fortio
+          FORTIO_DEB_VERSION="${FORTIO_VERSION#v}"
+          curl -L --fail -o fortio.deb "https://github.com/fortio/fortio/releases/download/${FORTIO_VERSION}/fortio_${FORTIO_DEB_VERSION}_amd64.deb"
+          sudo apt-get install -y ./fortio.deb
           fortio version
 
       - name: Create cluster and import local images

--- a/bench/run-faas-chain.sh
+++ b/bench/run-faas-chain.sh
@@ -14,6 +14,7 @@ if ! command -v fortio >/dev/null 2>&1; then
 fi
 
 mkdir -p "$RESULT_DIR"
+curl -sf --retry 5 --retry-delay 1 --max-time 30 "$CHAIN_URL" >/dev/null
 fortio load \
   -json "$RESULT_DIR/faas-chain-${CHAIN_LABEL}.json" \
   -qps "$QPS" \

--- a/core-host/src/host_core/component_hosts.rs
+++ b/core-host/src/host_core/component_hosts.rs
@@ -2563,6 +2563,27 @@ impl system_component_bindings::tachyon::mesh::model_events::Host for ComponentH
     }
 }
 
+impl component_bindings::tachyon::mesh::outbound_http::Host for ComponentHostState {
+    fn send_request(
+        &mut self,
+        method: String,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> std::result::Result<component_bindings::tachyon::mesh::outbound_http::Response, String>
+    {
+        let response =
+            <Self as background_component_bindings::tachyon::mesh::outbound_http::Host>::send_request(
+                self, method, url, headers, body,
+            )?;
+        Ok(component_bindings::tachyon::mesh::outbound_http::Response {
+            status: response.status,
+            headers: response.headers,
+            body: response.body,
+        })
+    }
+}
+
 impl background_component_bindings::tachyon::mesh::outbound_http::Host for ComponentHostState {
     fn send_request(
         &mut self,

--- a/core-host/src/host_core/guest_runtime.rs
+++ b/core-host/src/host_core/guest_runtime.rs
@@ -550,6 +550,18 @@ pub(crate) fn execute_component_guest(
         })?;
         // Infrastructure — streaming body sink; always linked. Guests that do
         // not call `get-streaming-response` incur no overhead.
+        if shape.grants(ScopeCategory::Http) {
+            component_bindings::tachyon::mesh::outbound_http::add_to_linker::<
+                ComponentHostState,
+                ComponentHostState,
+            >(&mut l, |s: &mut ComponentHostState| s)
+            .map_err(|e| {
+                guest_execution_error(
+                    e,
+                    "failed to add outbound HTTP functions to component linker",
+                )
+            })?;
+        }
         component_bindings::tachyon::mesh::response_body::add_to_linker::<
             ComponentHostState,
             ComponentHostState,
@@ -1196,6 +1208,15 @@ pub(crate) fn execute_streaming_component_guest(
                 ComponentHostState,
             >(&mut l, |s| s)
             .map_err(|e| guest_execution_error(e, "failed to add metrics to streaming linker"))?;
+            if shape.grants(ScopeCategory::Http) {
+                component_bindings::tachyon::mesh::outbound_http::add_to_linker::<
+                    ComponentHostState,
+                    ComponentHostState,
+                >(&mut l, |s| s)
+                .map_err(|e| {
+                    guest_execution_error(e, "failed to add outbound HTTP to streaming linker")
+                })?;
+            }
             component_bindings::tachyon::mesh::response_body::add_to_linker::<
                 ComponentHostState,
                 ComponentHostState,

--- a/core-host/src/host_core/prewarm.rs
+++ b/core-host/src/host_core/prewarm.rs
@@ -355,6 +355,16 @@ pub(crate) fn prewarm_http_component_instance(
             "failed to add training functions to prewarm HTTP component linker",
         )
     })?;
+    component_bindings::tachyon::mesh::outbound_http::add_to_linker::<
+        ComponentHostState,
+        ComponentHostState,
+    >(&mut linker, |state: &mut ComponentHostState| state)
+    .map_err(|error| {
+        guest_execution_error(
+            error,
+            "failed to add outbound HTTP functions to prewarm HTTP component linker",
+        )
+    })?;
     #[cfg(feature = "ai-inference")]
     add_accelerator_interfaces_to_component_linker(
         &mut linker,

--- a/examples/guest-chain-a/src/lib.rs
+++ b/examples/guest-chain-a/src/lib.rs
@@ -3,7 +3,7 @@ mod bindings {
 
     wit_bindgen::generate!({
         path: "../../wit/tachyon.wit",
-        world: "system-faas-guest",
+        world: "faas-guest",
     });
 
     export!(Component);

--- a/examples/guest-chain-b/src/lib.rs
+++ b/examples/guest-chain-b/src/lib.rs
@@ -3,7 +3,7 @@ mod bindings {
 
     wit_bindgen::generate!({
         path: "../../wit/tachyon.wit",
-        world: "system-faas-guest",
+        world: "faas-guest",
     });
 
     export!(Component);

--- a/sdk/wit/tachyon.wit
+++ b/sdk/wit/tachyon.wit
@@ -239,6 +239,7 @@ world faas-guest {
     import vector;
     import training;
     import kv-partition;
+    import outbound-http;
     export handler;
 }
 

--- a/wit/tachyon.wit
+++ b/wit/tachyon.wit
@@ -327,6 +327,7 @@ world faas-guest {
     import kv-partition;
     import graph;
     import custom-metrics;
+    import outbound-http;
     import response-body;
     export handler;
 }


### PR DESCRIPTION
## Summary
- update the Bench Regression Fortio install step to use the current release .deb asset naming
- add curl --fail so missing Fortio assets fail at download time instead of executing a 404 body
- expose scoped outbound HTTP to the user faas-guest world and compile the bench chain guests against that world
- warm the FaaS chain once before Fortio so startup/prewarm latency does not abort the throughput sample

## Verification
- confirmed the current Fortio amd64 .deb release URL returns 200 OK
- cargo fmt --all --check
- cargo check -p guest-chain-a --target wasm32-wasip2
- cargo check -p guest-chain-b --target wasm32-wasip2
- cargo check -p core-host