### PR TITLE
Publish versioned manifest schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,62 @@ jobs:
       - name: Run cargo deny
         run: cargo deny check advisories bans sources
 
-  # ── 3. Quality gate (runs in parallel with build-guests + security-audit) ───
-  # Fast checks that gate everything downstream: fmt, clippy, cross-layer
-  # validation and per-feature compilation checks.
-  # cargo build -p tachyon-ui --release is intentionally absent: clippy
-  # --workspace already verifies the crate compiles, and the Publish Tachyon
-  # Desktop workflow handles the full Tauri bundle on main and version tags.
+  # Offline manifest schemas must stay compatible with the latest published
+  # release unless a PR intentionally carries the breaking-manifest label.
+  manifest-schema-compatibility:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      GH_TOKEN: ${{ github.token }}
+      BREAKING_MANIFEST_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'breaking-manifest') }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate HEAD integrity schemas
+        run: cargo run -p core-host -- schema --output-dir target/schemas-head
+
+      - name: Download latest release integrity schemas
+        id: previous
+        shell: bash
+        run: |
+          tag="$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName // ""')"
+          if [ -z "$tag" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No previous release found; skipping manifest schema compatibility diff."
+            exit 0
+          fi
+          mkdir -p target/schemas-prev
+          if ! gh release download "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir target/schemas-prev \
+            --pattern integrity-config.schema.json \
+            --pattern integrity-lock.schema.json; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Latest release $tag has no integrity schema assets; skipping compatibility diff."
+            exit 0
+          fi
+          if [ ! -f target/schemas-prev/integrity-config.schema.json ] || [ ! -f target/schemas-prev/integrity-lock.schema.json ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Latest release $tag does not include both integrity schema assets; skipping compatibility diff."
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check manifest schema compatibility
+        if: steps.previous.outputs.found == 'true' && env.BREAKING_MANIFEST_LABEL != 'true'
+        run: |
+          node scripts/check-schema-compat.js target/schemas-prev/integrity-config.schema.json target/schemas-head/integrity-config.schema.json
+          node scripts/check-schema-compat.js target/schemas-prev/integrity-lock.schema.json target/schemas-head/integrity-lock.schema.json
+
+      - name: Acknowledge intentional manifest break
+        if: steps.previous.outputs.found == 'true' && env.BREAKING_MANIFEST_LABEL == 'true'
+        run: echo "breaking-manifest label present; schema compatibility diff is advisory for this PR."
+
+  # Quality gate: fmt, clippy, cross-layer validation and per-feature compilation checks.
   quality:
     runs-on: ubuntu-latest
     env:
@@ -927,7 +977,7 @@ jobs:
   # blocks on it.
   publish-docker-images:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [docker-base, quality, test, cover, release, feature-matrix-tests, fips-tests]
+    needs: [docker-base, quality, manifest-schema-compatibility, test, cover, release, feature-matrix-tests, fips-tests]
     runs-on: ubuntu-latest
     env:
       BUILDKIT_PROGRESS: plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publish-integrity-schemas:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate versioned integrity schemas
+        run: cargo run -p core-host -- schema --output-dir target/schemas --release-tag "${{ github.ref_name }}"
+
+      - name: Upload schema assets to GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            target/schemas/integrity-config.schema.json
+            target/schemas/integrity-lock.schema.json
+
   # ── Server-side binary tarballs (core-host + tachyon-mcp) ────────────────────
   # Published only on version tags; used by scripts/get-tachyon.sh.
   publish-server-binaries:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ wkg list ghcr.io/astorise/tachyon-mesh-wit
 
 ## 🛠️ IDE Integration & Schema Validation
 
-While `core-host` is running, it serves live JSON Schema documents for its configuration files — enabling real-time validation and autocompletion in VS Code, JetBrains, and Neovim without copying schema files.
+While `core-host` is running, it serves live JSON Schema documents for its configuration files — enabling real-time validation and autocompletion in VS Code, JetBrains, and Neovim without copying schema files. Each versioned GitHub release also publishes offline `integrity-config.schema.json` and `integrity-lock.schema.json` assets with release-pinned `$id` values.
+
+Use release URLs such as `https://github.com/astorise/tachyon-mesh/releases/download/v1.2.3/integrity-config.schema.json` when you need a stable `$schema` value for CI, air-gapped validation, or editor completion pinned to a Tachyon version.
 
 **VS Code quick setup** (`.vscode/settings.json`):
 ```json

--- a/core-host/src/host_core.rs
+++ b/core-host/src/host_core.rs
@@ -149,6 +149,7 @@ pub(crate) mod openapi;
 mod peer_pressure;
 mod prewarm;
 mod runtime_types;
+mod schema;
 pub(crate) mod scoping;
 mod storage_broker;
 mod supervisors;
@@ -173,6 +174,7 @@ pub(crate) use mesh_dispatch_metrics::*;
 pub(crate) use peer_pressure::*;
 pub(crate) use prewarm::*;
 pub(crate) use runtime_types::*;
+pub(crate) use schema::*;
 pub(crate) use supervisors::*;
 pub(crate) use volumes::*;
 

--- a/core-host/src/host_core/admin_plane.rs
+++ b/core-host/src/host_core/admin_plane.rs
@@ -204,7 +204,7 @@ pub(crate) async fn admin_metrics_handler(
 /// format accepted by `POST /admin/manifest`. LLM agents and MCP clients can
 /// fetch this schema to validate manifest payloads before submission.
 pub(crate) async fn admin_manifest_schema_handler() -> axum::Json<serde_json::Value> {
-    axum::Json(integrity_config_schema())
+    axum::Json(integrity_config_schema(None))
 }
 
 /// Serves the OpenAPI 3.1 JSON document generated from the compile-time `ApiDoc`.
@@ -219,22 +219,12 @@ pub(crate) async fn admin_openapi_schema_handler() -> impl IntoResponse {
 
 /// Serves a JSON Schema describing the `integrity.lock` file format.
 pub(crate) async fn admin_integrity_lock_schema_handler() -> impl IntoResponse {
-    let schema = integrity_manifest_schema();
+    let schema = integrity_manifest_schema(None);
     (
         StatusCode::OK,
         [(axum::http::header::CONTENT_TYPE, "application/json")],
         schema.to_string(),
     )
-}
-
-fn integrity_config_schema() -> serde_json::Value {
-    serde_json::to_value(schemars::schema_for!(IntegrityConfig))
-        .expect("IntegrityConfig JSON Schema should serialize")
-}
-
-fn integrity_manifest_schema() -> serde_json::Value {
-    serde_json::to_value(schemars::schema_for!(IntegrityManifest))
-        .expect("IntegrityManifest JSON Schema should serialize")
 }
 
 #[cfg(test)]
@@ -243,7 +233,7 @@ mod schema_tests {
 
     #[test]
     fn manifest_schema_uses_integrity_config_field_names() {
-        let schema = integrity_config_schema();
+        let schema = integrity_config_schema(None);
         let properties = schema
             .get("properties")
             .and_then(serde_json::Value::as_object)
@@ -261,7 +251,7 @@ mod schema_tests {
 
     #[test]
     fn manifest_schema_covers_route_nested_config() {
-        let schema = integrity_config_schema();
+        let schema = integrity_config_schema(None);
         let text = schema.to_string();
 
         for field in [
@@ -287,7 +277,7 @@ mod schema_tests {
 
     #[test]
     fn integrity_lock_schema_uses_signed_manifest_field_names() {
-        let schema = integrity_manifest_schema();
+        let schema = integrity_manifest_schema(None);
         let properties = schema
             .get("properties")
             .and_then(serde_json::Value::as_object)
@@ -298,6 +288,20 @@ mod schema_tests {
         assert!(properties.contains_key("signature"));
         assert!(!properties.contains_key("configPayload"));
         assert!(!properties.contains_key("hostAddress"));
+    }
+
+    #[test]
+    fn release_schema_id_targets_release_asset() {
+        let schema = integrity_config_schema(Some(&release_schema_id(
+            "v1.2.3",
+            INTEGRITY_CONFIG_SCHEMA_FILE,
+        )));
+        assert_eq!(
+            schema.get("$id").and_then(serde_json::Value::as_str),
+            Some(
+                "https://github.com/astorise/tachyon-mesh/releases/download/v1.2.3/integrity-config.schema.json"
+            )
+        );
     }
 }
 

--- a/core-host/src/host_core/domain_types.rs
+++ b/core-host/src/host_core/domain_types.rs
@@ -1277,6 +1277,7 @@ pub(crate) enum AccelerationMode {
 pub(crate) enum HostCommand {
     Serve,
     Run(RunCommand),
+    Schema(SchemaCommand),
 }
 
 #[derive(Debug, ClapArgs)]
@@ -1285,6 +1286,16 @@ pub(crate) struct RunCommand {
     pub(crate) manifest: Option<PathBuf>,
     #[arg(long)]
     pub(crate) target: String,
+}
+
+#[derive(Debug, ClapArgs)]
+pub(crate) struct SchemaCommand {
+    /// Directory receiving integrity-config.schema.json and integrity-lock.schema.json.
+    #[arg(long, default_value = "target/schemas")]
+    pub(crate) output_dir: PathBuf,
+    /// Release tag used to stamp each schema's $id, for example v1.2.3.
+    #[arg(long)]
+    pub(crate) release_tag: Option<String>,
 }
 
 #[cfg(test)]

--- a/core-host/src/host_core/entrypoint.rs
+++ b/core-host/src/host_core/entrypoint.rs
@@ -22,6 +22,10 @@ pub(crate) async fn run() -> Result<()> {
             };
             std::process::exit(exit_code);
         }
+        HostCommand::Schema(command) => {
+            write_integrity_schema_files(&command)?;
+            Ok(())
+        }
     }
 }
 

--- a/core-host/src/host_core/schema.rs
+++ b/core-host/src/host_core/schema.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+pub(crate) const INTEGRITY_CONFIG_SCHEMA_FILE: &str = "integrity-config.schema.json";
+pub(crate) const INTEGRITY_LOCK_SCHEMA_FILE: &str = "integrity-lock.schema.json";
+
+pub(crate) fn integrity_config_schema(schema_id: Option<&str>) -> serde_json::Value {
+    schema_with_id(
+        serde_json::to_value(schemars::schema_for!(IntegrityConfig))
+            .expect("IntegrityConfig JSON Schema should serialize"),
+        schema_id,
+    )
+}
+
+pub(crate) fn integrity_manifest_schema(schema_id: Option<&str>) -> serde_json::Value {
+    schema_with_id(
+        serde_json::to_value(schemars::schema_for!(IntegrityManifest))
+            .expect("IntegrityManifest JSON Schema should serialize"),
+        schema_id,
+    )
+}
+
+pub(crate) fn release_schema_id(release_tag: &str, file_name: &str) -> String {
+    format!("https://github.com/astorise/tachyon-mesh/releases/download/{release_tag}/{file_name}")
+}
+
+pub(crate) fn write_integrity_schema_files(command: &SchemaCommand) -> Result<()> {
+    fs::create_dir_all(&command.output_dir).with_context(|| {
+        format!(
+            "failed to create schema output directory {}",
+            command.output_dir.display()
+        )
+    })?;
+
+    let config_id = command
+        .release_tag
+        .as_deref()
+        .map(|tag| release_schema_id(tag, INTEGRITY_CONFIG_SCHEMA_FILE));
+    let lock_id = command
+        .release_tag
+        .as_deref()
+        .map(|tag| release_schema_id(tag, INTEGRITY_LOCK_SCHEMA_FILE));
+
+    write_schema_file(
+        &command.output_dir.join(INTEGRITY_CONFIG_SCHEMA_FILE),
+        integrity_config_schema(config_id.as_deref()),
+    )?;
+    write_schema_file(
+        &command.output_dir.join(INTEGRITY_LOCK_SCHEMA_FILE),
+        integrity_manifest_schema(lock_id.as_deref()),
+    )?;
+    Ok(())
+}
+
+fn write_schema_file(path: &Path, schema: serde_json::Value) -> Result<()> {
+    let data =
+        serde_json::to_string_pretty(&schema).expect("JSON Schema document should serialize");
+    fs::write(path, format!("{data}\n"))
+        .with_context(|| format!("failed to write schema file {}", path.display()))
+}
+
+fn schema_with_id(mut schema: serde_json::Value, schema_id: Option<&str>) -> serde_json::Value {
+    if let Some(schema_id) = schema_id {
+        if let Some(object) = schema.as_object_mut() {
+            object.insert(
+                "$id".to_owned(),
+                serde_json::Value::String(schema_id.to_owned()),
+            );
+        }
+    }
+    schema
+}

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -1,6 +1,8 @@
 # IDE Integration & Schema Validation
 
-Tachyon Mesh dynamically serves JSON Schema documents for its configuration files while `core-host` is running. Binding these to your IDE gives real-time validation and autocompletion — no copying `.schema.json` files needed.
+Tachyon Mesh serves JSON Schema documents for its configuration files while `core-host` is running. Binding these to your IDE gives real-time validation and autocompletion without copying `.schema.json` files.
+
+For offline, CI, or air-gapped validation, every versioned GitHub release also publishes `integrity-config.schema.json` and `integrity-lock.schema.json` assets. Those release assets include a versioned `$id`, for example `https://github.com/astorise/tachyon-mesh/releases/download/v1.2.3/integrity-config.schema.json`.
 
 ## Prerequisites
 
@@ -115,7 +117,7 @@ require("lspconfig").jsonls.setup({
 
 ## Offline / Air-Gapped Environments
 
-If you cannot reach a running `core-host`, fetch the schemas once and commit them:
+If you cannot reach a running `core-host`, either download the versioned release assets or fetch the live schemas once and commit them:
 
 ```bash
 curl -s http://127.0.0.1:8080/admin/schema/integrity-lock > .schemas/integrity-lock.json
@@ -123,3 +125,11 @@ curl -s http://127.0.0.1:8080/admin/schema/manifest       > .schemas/manifest.js
 ```
 
 Then point your IDE configuration to the local paths instead of the HTTP URLs.
+
+To generate schemas directly from a source checkout:
+
+```bash
+cargo run -p core-host -- schema --output-dir .schemas --release-tag v1.2.3
+```
+
+CI compares the generated HEAD schemas against the latest release assets. Adding a required field, removing a field, changing a type, or removing an enum value fails the compatibility check unless the PR carries the `breaking-manifest` label.

--- a/openspec/specs/core-host/spec.md
+++ b/openspec/specs/core-host/spec.md
@@ -127,6 +127,15 @@ A new endpoint `GET /admin/schema/integrity-lock` SHALL return a JSON Schema doc
 - **THEN** the response is JSON with top-level `config_payload`, `public_key`, and `signature` properties
 - **AND** it does not document camelCase runtime fields such as `hostAddress`
 
+### Requirement: core-host MUST generate release-ready manifest schema files
+The `core-host` binary SHALL provide a `schema` command that writes `integrity-config.schema.json` from `IntegrityConfig` and `integrity-lock.schema.json` from `IntegrityManifest`. The generated file schemas SHALL use the same schemars generation path as the live admin endpoints. When a release tag is supplied, each schema SHALL include a `$id` pointing at the corresponding GitHub Release asset URL.
+
+#### Scenario: Operator generates versioned schema files from source
+- **WHEN** a developer runs `cargo run -p core-host -- schema --output-dir target/schemas --release-tag v1.2.3`
+- **THEN** `target/schemas/integrity-config.schema.json` is written from the `IntegrityConfig` schema
+- **AND** `target/schemas/integrity-lock.schema.json` is written from the `IntegrityManifest` schema
+- **AND** each schema contains a `$id` under `https://github.com/astorise/tachyon-mesh/releases/download/v1.2.3/`
+
 ### Requirement: core-host MUST expose a zero-copy layer-wise inference WIT contract
 The project SHALL define `wit/ai/inference.wit` in the existing `tachyon:mesh@1.1.0` WIT package and SHALL expose a `layer-execution` interface with opaque `tensor-handle` values so Wasm guests can sequence model layers without copying intermediate tensors through linear memory.
 

--- a/openspec/specs/github-actions/spec.md
+++ b/openspec/specs/github-actions/spec.md
@@ -119,7 +119,7 @@ The release workflow SHALL publish `integrity-config.schema.json` and `integrity
 - **AND** it uploads both files to the GitHub Release for that tag
 
 ### Requirement: CI checks manifest schema compatibility against the latest release
-The CI workflow SHALL generate HEAD integrity schemas and compare them with the latest non-draft, non-prerelease GitHub Release schema assets when both previous assets exist. Adding required fields, removing properties, changing schema types, or removing enum values SHALL fail CI unless the pull request is explicitly labeled `breaking-manifest`.
+The CI workflow SHALL generate HEAD integrity schemas and compare them with the latest non-draft, non-prerelease GitHub Release schema assets when both previous assets exist. Adding required fields, removing properties, changing schema types, changing `const` literal values, removing enum values, or removing `oneOf`/`anyOf` variants SHALL fail CI unless the pull request is explicitly labeled `breaking-manifest`.
 
 #### Scenario: Backward-incompatible manifest schema change fails CI
 - **WHEN** a pull request changes the generated manifest schema incompatibly with the latest release assets

--- a/openspec/specs/github-actions/spec.md
+++ b/openspec/specs/github-actions/spec.md
@@ -109,6 +109,27 @@ The desktop release workflow SHALL build the Tauri bundles from the `tachyon-ui`
 - **THEN** `projectPath` points to `tachyon-ui`
 - **AND** frontend dependencies are installed from the `tachyon-ui` directory
 
+### Requirement: Release workflow publishes versioned integrity schema assets
+The release workflow SHALL publish `integrity-config.schema.json` and `integrity-lock.schema.json` as GitHub Release assets for version tags. The workflow SHALL generate those files from the checked-out source using `core-host schema` and stamp their `$id` values with the pushed release tag.
+
+#### Scenario: Release tag uploads manifest schema assets
+- **WHEN** a maintainer pushes a tag such as `v1.2.3`
+- **THEN** the release workflow runs a schema publishing job on a Linux runner
+- **AND** it generates `integrity-config.schema.json` and `integrity-lock.schema.json`
+- **AND** it uploads both files to the GitHub Release for that tag
+
+### Requirement: CI checks manifest schema compatibility against the latest release
+The CI workflow SHALL generate HEAD integrity schemas and compare them with the latest non-draft, non-prerelease GitHub Release schema assets when both previous assets exist. Adding required fields, removing properties, changing schema types, or removing enum values SHALL fail CI unless the pull request is explicitly labeled `breaking-manifest`.
+
+#### Scenario: Backward-incompatible manifest schema change fails CI
+- **WHEN** a pull request changes the generated manifest schema incompatibly with the latest release assets
+- **AND** the pull request does not carry the `breaking-manifest` label
+- **THEN** the manifest schema compatibility job fails and reports the breaking paths
+
+#### Scenario: Missing historical schema assets skip the diff
+- **WHEN** the latest release does not include both integrity schema assets
+- **THEN** CI records a notice and skips the compatibility diff rather than failing unrelated changes
+
 ### Requirement: Release workflow MUST publish Windows binaries as .zip
 The `publish-server-binaries` matrix SHALL include `windows-latest / x86_64-pc-windows-msvc`. The packaging step SHALL produce `tachyon-mesh-VERSION-windows-x86_64.zip` containing `core-host.exe` and `tachyon-mcp.exe`.
 

--- a/scripts/check-schema-compat.js
+++ b/scripts/check-schema-compat.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+if (process.argv.length !== 4) {
+  console.error('usage: check-schema-compat.js <previous.schema.json> <current.schema.json>');
+  process.exit(2);
+}
+
+const previousPath = process.argv[2];
+const currentPath = process.argv[3];
+const previous = JSON.parse(fs.readFileSync(previousPath, 'utf8'));
+const current = JSON.parse(fs.readFileSync(currentPath, 'utf8'));
+const failures = [];
+
+function pointerGet(root, ref) {
+  if (!ref.startsWith('#/')) {
+    return null;
+  }
+  return ref
+    .slice(2)
+    .split('/')
+    .reduce((value, part) => {
+      if (value === null || typeof value !== 'object') {
+        return null;
+      }
+      const key = part.replace(/~1/g, '/').replace(/~0/g, '~');
+      return value[key] ?? null;
+    }, root);
+}
+
+function resolve(root, schema) {
+  if (schema && typeof schema === 'object' && typeof schema.$ref === 'string') {
+    return pointerGet(root, schema.$ref) ?? schema;
+  }
+  return schema;
+}
+
+function normalizeTypes(schema) {
+  const type = schema?.type;
+  if (Array.isArray(type)) {
+    return [...type].sort().join('|');
+  }
+  if (typeof type === 'string') {
+    return type;
+  }
+  if (schema?.const !== undefined) {
+    return 'const';
+  }
+  if (Array.isArray(schema?.enum)) {
+    return 'enum';
+  }
+  if (Array.isArray(schema?.oneOf)) {
+    return 'oneOf';
+  }
+  if (Array.isArray(schema?.anyOf)) {
+    return 'anyOf';
+  }
+  return '';
+}
+
+function pathLabel(parts) {
+  return parts.length === 0 ? '<root>' : parts.join('.');
+}
+
+function compareSchemas(previousRoot, currentRoot, previousSchema, currentSchema, parts = []) {
+  previousSchema = resolve(previousRoot, previousSchema);
+  currentSchema = resolve(currentRoot, currentSchema);
+  if (!previousSchema || !currentSchema) {
+    return;
+  }
+
+  const previousType = normalizeTypes(previousSchema);
+  const currentType = normalizeTypes(currentSchema);
+  if (previousType && currentType && previousType !== currentType) {
+    failures.push(
+      `${pathLabel(parts)} changed type from ${previousType} to ${currentType}`
+    );
+    return;
+  }
+
+  if (Array.isArray(previousSchema.enum) && Array.isArray(currentSchema.enum)) {
+    const currentValues = new Set(currentSchema.enum.map((value) => JSON.stringify(value)));
+    for (const value of previousSchema.enum) {
+      if (!currentValues.has(JSON.stringify(value))) {
+        failures.push(`${pathLabel(parts)} removed enum value ${JSON.stringify(value)}`);
+      }
+    }
+  }
+
+  const previousRequired = new Set(previousSchema.required ?? []);
+  const currentRequired = new Set(currentSchema.required ?? []);
+  for (const field of currentRequired) {
+    if (!previousRequired.has(field)) {
+      failures.push(`${pathLabel(parts)} added required field ${field}`);
+    }
+  }
+
+  const previousProperties = previousSchema.properties ?? {};
+  const currentProperties = currentSchema.properties ?? {};
+  for (const field of Object.keys(previousProperties)) {
+    if (!(field in currentProperties)) {
+      failures.push(`${pathLabel([...parts, field])} was removed`);
+      continue;
+    }
+    compareSchemas(
+      previousRoot,
+      currentRoot,
+      previousProperties[field],
+      currentProperties[field],
+      [...parts, field]
+    );
+  }
+
+  const previousItems = previousSchema.items;
+  const currentItems = currentSchema.items;
+  if (previousItems && currentItems) {
+    compareSchemas(previousRoot, currentRoot, previousItems, currentItems, [...parts, '[]']);
+  }
+
+  const previousAdditional = previousSchema.additionalProperties;
+  const currentAdditional = currentSchema.additionalProperties;
+  if (
+    previousAdditional &&
+    currentAdditional &&
+    typeof previousAdditional === 'object' &&
+    typeof currentAdditional === 'object'
+  ) {
+    compareSchemas(previousRoot, currentRoot, previousAdditional, currentAdditional, [
+      ...parts,
+      '{}',
+    ]);
+  }
+
+  for (const key of ['allOf', 'anyOf', 'oneOf']) {
+    const previousVariants = previousSchema[key];
+    const currentVariants = currentSchema[key];
+    if (!Array.isArray(previousVariants) || !Array.isArray(currentVariants)) {
+      continue;
+    }
+    const count = Math.min(previousVariants.length, currentVariants.length);
+    for (let index = 0; index < count; index += 1) {
+      compareSchemas(previousRoot, currentRoot, previousVariants[index], currentVariants[index], [
+        ...parts,
+        `${key}[${index}]`,
+      ]);
+    }
+  }
+}
+
+compareSchemas(previous, current, previous, current);
+
+if (failures.length > 0) {
+  console.error(
+    `${path.basename(currentPath)} has ${failures.length} breaking schema change(s):`
+  );
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  console.error('Add the breaking-manifest label or publish this change as a manifest break.');
+  process.exit(1);
+}
+
+console.log(`${path.basename(currentPath)} is backward-compatible with ${path.basename(previousPath)}`);

--- a/scripts/check-schema-compat.js
+++ b/scripts/check-schema-compat.js
@@ -79,6 +79,16 @@ function compareSchemas(previousRoot, currentRoot, previousSchema, currentSchema
     return;
   }
 
+  if (
+    previousSchema.const !== undefined &&
+    currentSchema.const !== undefined &&
+    JSON.stringify(previousSchema.const) !== JSON.stringify(currentSchema.const)
+  ) {
+    failures.push(
+      `${pathLabel(parts)} changed const from ${JSON.stringify(previousSchema.const)} to ${JSON.stringify(currentSchema.const)}`
+    );
+  }
+
   if (Array.isArray(previousSchema.enum) && Array.isArray(currentSchema.enum)) {
     const currentValues = new Set(currentSchema.enum.map((value) => JSON.stringify(value)));
     for (const value of previousSchema.enum) {
@@ -137,6 +147,11 @@ function compareSchemas(previousRoot, currentRoot, previousSchema, currentSchema
     const currentVariants = currentSchema[key];
     if (!Array.isArray(previousVariants) || !Array.isArray(currentVariants)) {
       continue;
+    }
+    if ((key === 'anyOf' || key === 'oneOf') && currentVariants.length < previousVariants.length) {
+      failures.push(
+        `${pathLabel(parts)} removed ${previousVariants.length - currentVariants.length} ${key} variant(s)`
+      );
     }
     const count = Math.min(previousVariants.length, currentVariants.length);
     for (let index = 0; index < count; index += 1) {


### PR DESCRIPTION
﻿## Summary
- add `core-host schema` to generate `integrity-config.schema.json` and `integrity-lock.schema.json` with release-pinned `$id` values
- publish the generated schema files as versioned release assets
- add CI compatibility checks against the latest release schema assets, with `breaking-manifest` as the explicit break label
- document offline schema usage and update OpenSpec requirements

Fixes #314

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p core-host schema_tests`
- `cargo run -p core-host -- schema --output-dir target/schemas-test --release-tag v9.9.9`
- `node scripts/check-schema-compat.js target/schemas-test/integrity-config.schema.json target/schemas-test/integrity-config.schema.json`
- `node scripts/check-schema-compat.js target/schemas-test/integrity-lock.schema.json target/schemas-test/integrity-lock.schema.json`
- `python -c "import yaml; [yaml.safe_load(open(p, encoding='utf-8')) for p in ['.github/workflows/ci.yml','.github/workflows/release.yml']]; print('workflow yaml ok')"`
- `openspec validate --all`