### PR TITLE
Add RAG vector MCP demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,8 @@ dependencies = [
 name = "guest-rag-vector"
 version = "1.0.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "wit-bindgen 0.46.0",
 ]
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -79,6 +79,7 @@ The server speaks JSON-RPC 2.0 over stdin/stdout.
 | `tachyon_run_chaos_scenario` | Trigger a named chaos harness scenario |
 | `tachyon_hardware_status` | Local RAM and accelerator inventory |
 | `validate_faas_capabilities` | Check whether a hardware policy is admissible |
+| `tachyon_vector_search` | Read-only RAG/vector query via `/api/guest-rag-vector`; see [RAG vector search demo](rag-vector-search.md) |
 
 ---
 
@@ -88,6 +89,7 @@ The server speaks JSON-RPC 2.0 over stdin/stdout.
 |----------|----------|-------------|
 | `TACHYON_MCP_URL` | Yes | Base URL of a running `core-host` (e.g. `http://127.0.0.1:8080`) |
 | `TACHYON_MCP_PAT` | Yes | Personal Access Token with operator privileges |
+| `TACHYON_MCP_VECTOR_SEARCH_PATH` | No | Route used by `tachyon_vector_search` when `route_path` is omitted. Defaults to `/api/guest-rag-vector` |
 
 ## Available resources
 

--- a/docs/rag-vector-search.md
+++ b/docs/rag-vector-search.md
@@ -1,0 +1,112 @@
+# RAG vector search demo
+
+This guide wires the end-to-end RAG example from `examples/guest-rag-vector`:
+
+1. ingest documents,
+2. call the OpenAI-compatible embeddings route when available,
+3. upsert vectors through the `tachyon:mesh/vector` WIT import,
+4. search the ANN index,
+5. call `/ai/v1/chat/completions` with retrieved context when available,
+6. expose the same query flow to agents through `tachyon_vector_search`.
+
+The example has local deterministic fallbacks for embeddings and completion, so
+it can be smoke-tested before a real model is uploaded. When `/ai/v1/embeddings`
+and `/ai/v1/chat/completions` are backed by `guest-openai`, the same guest uses
+those routes through Tachyon's internal mesh dispatch path.
+
+## Build the guest
+
+```powershell
+cargo build -p guest-rag-vector --target wasm32-wasip2 --release
+```
+
+The artifact is emitted at:
+
+```text
+target/wasm32-wasip2/release/guest_rag_vector.wasm
+```
+
+## Import the route
+
+`examples/guest-rag-vector/manifest.json` declares `/api/guest-rag-vector` with:
+
+- `vector` scope for `tenant-kb` and `demo-*`,
+- `http` scope for `/ai/v1/embeddings` and `/ai/v1/chat/completions`,
+- dependencies on the OpenAI-compatible routes used for in-process dispatch.
+
+Package the WASM and manifest with the same archive shape accepted by
+`tachyon_import_package`, then import it:
+
+```json
+{
+  "package_path": "C:\\path\\to\\guest-rag-vector.tar.gz"
+}
+```
+
+If you prefer direct deployment while iterating, upload the WASM with
+`tachyon_deploy_function`, then apply the scopes from the manifest with
+`tachyon_patch_route`.
+
+## Smoke-test HTTP RAG
+
+```powershell
+$body = @{
+  query = "How does the MCP vector tool reach RAG context?"
+  index = "tenant-kb"
+  topK = 3
+} | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "$env:TACHYON_MCP_URL/api/guest-rag-vector" `
+  -Headers @{ Authorization = "Bearer $env:TACHYON_MCP_PAT" } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+Expected response fields:
+
+- `answer`: model answer or fallback answer grounded in the best match,
+- `matches`: nearest documents with scores and payload text,
+- `embeddingSource`: `openai-compatible:<model>` or local fallback,
+- `completionSource`: `openai-compatible:<model>` or local fallback.
+
+To ingest your own demo corpus for the request:
+
+```json
+{
+  "query": "What protects outbound calls?",
+  "index": "tenant-kb",
+  "topK": 2,
+  "documents": [
+    { "id": "scopes", "text": "Tachyon validates WIT imports against per-route scopes." },
+    { "id": "dispatch", "text": "Internal mesh routes can dispatch in-process on the same node." }
+  ]
+}
+```
+
+## Agent access through MCP
+
+`tachyon-mcp` now advertises the read-only tool:
+
+```json
+{
+  "name": "tachyon_vector_search",
+  "arguments": {
+    "query": "What is the vector WIT interface used for?",
+    "index": "tenant-kb",
+    "top_k": 3
+  }
+}
+```
+
+Optional arguments:
+
+- `route_path`: override the default `/api/guest-rag-vector`; can also be set
+  with `TACHYON_MCP_VECTOR_SEARCH_PATH`,
+- `embedding_model`: embedding model alias passed to the RAG route,
+- `chat_model`: chat model alias passed to the RAG route,
+- `documents`: temporary documents to ingest before the search.
+
+The MCP server applies the normal connection/auth flow (`TACHYON_MCP_URL` and
+`TACHYON_MCP_PAT`) and rate-limits the tool as a high-throughput read operation.

--- a/docs/rag-vector-search.md
+++ b/docs/rag-vector-search.md
@@ -68,7 +68,7 @@ Expected response fields:
 
 - `answer`: model answer or fallback answer grounded in the best match,
 - `matches`: nearest documents with scores and payload text,
-- `effectiveIndex`: temporary dimension/source-specific index used internally,
+- `effectiveIndex`: temporary per-request, dimension/source-specific index used internally,
 - `embeddingSource`: `openai-compatible:<model>` or local fallback,
 - `completionSource`: `openai-compatible:<model>` or local fallback.
 
@@ -110,4 +110,6 @@ Optional arguments:
 - `documents`: temporary documents to ingest before the search.
 
 The MCP server applies the normal connection/auth flow (`TACHYON_MCP_URL` and
-`TACHYON_MCP_PAT`) and rate-limits the tool as a high-throughput read operation.
+`TACHYON_MCP_PAT`), injects an internal request identifier so temporary vector
+documents are isolated per call, and rate-limits the tool as a high-throughput
+read operation.

--- a/docs/rag-vector-search.md
+++ b/docs/rag-vector-search.md
@@ -68,6 +68,7 @@ Expected response fields:
 
 - `answer`: model answer or fallback answer grounded in the best match,
 - `matches`: nearest documents with scores and payload text,
+- `effectiveIndex`: temporary dimension/source-specific index used internally,
 - `embeddingSource`: `openai-compatible:<model>` or local fallback,
 - `completionSource`: `openai-compatible:<model>` or local fallback.
 

--- a/examples/guest-rag-vector/Cargo.toml
+++ b/examples/guest-rag-vector/Cargo.toml
@@ -8,3 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wit-bindgen = "0.46"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/examples/guest-rag-vector/manifest.json
+++ b/examples/guest-rag-vector/manifest.json
@@ -1,0 +1,21 @@
+{
+  "routes": [
+    {
+      "path": "/api/guest-rag-vector",
+      "role": "user",
+      "name": "guest-rag-vector",
+      "targets": [{ "module": "guest-rag-vector", "weight": 100 }],
+      "min_instances": 0,
+      "max_concurrency": 100,
+      "version": "1.0.0",
+      "scopes": {
+        "vector": ["tenant-kb", "demo-*"],
+        "http": ["/ai/v1/embeddings", "/ai/v1/chat/completions"]
+      },
+      "dependencies": {
+        "openai-embeddings": "^1.0",
+        "openai-chat": "^1.0"
+      }
+    }
+  ]
+}

--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -45,6 +45,7 @@ struct InputDocument {
 struct RagResponse {
     query: String,
     index: String,
+    effective_index: String,
     answer: String,
     matches: Vec<RagMatch>,
     embedding_source: String,
@@ -118,10 +119,16 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
     let query_embedding = embeddings
         .pop()
         .ok_or_else(|| "embedding pipeline returned no query embedding".to_owned())?;
+    let effective_index = effective_index_name(
+        &request.index,
+        &embedding_source,
+        query_embedding.len() as u32,
+    );
+    let request_prefix = request_doc_prefix(&request.query, &effective_index, &documents);
 
     let _ = bindings::tachyon::mesh::vector::create_index(
         &bindings::tachyon::mesh::vector::IndexSpec {
-            name: request.index.clone(),
+            name: effective_index.clone(),
             dim: query_embedding.len() as u32,
             m: 16,
             ef_construction: 200,
@@ -133,28 +140,38 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
         .zip(embeddings.iter())
         .map(
             |(doc, embedding)| bindings::tachyon::mesh::vector::Document {
-                id: doc.id.clone(),
+                id: temp_doc_id(&request_prefix, &doc.id),
                 embedding: embedding.clone(),
-                payload: Some(doc.text.as_bytes().to_vec()),
+                payload: Some(
+                    serde_json::to_vec(doc).unwrap_or_else(|_| doc.text.as_bytes().to_vec()),
+                ),
             },
         )
         .collect::<Vec<_>>();
-    bindings::tachyon::mesh::vector::upsert(&request.index, &vector_docs)
+    bindings::tachyon::mesh::vector::upsert(&effective_index, &vector_docs)
         .map_err(|error| format!("vector upsert failed: {error}"))?;
 
-    let matches =
-        bindings::tachyon::mesh::vector::search(&request.index, &query_embedding, request.top_k)
-            .map_err(|error| format!("vector search failed: {error}"))?
-            .into_iter()
-            .map(|item| RagMatch {
-                id: item.id,
+    let search_result =
+        bindings::tachyon::mesh::vector::search(&effective_index, &query_embedding, request.top_k);
+    cleanup_temp_docs(&effective_index, &vector_docs)?;
+    let matches = search_result
+        .map_err(|error| format!("vector search failed: {error}"))?
+        .into_iter()
+        .map(|item| {
+            let payload = item.payload.unwrap_or_default();
+            let doc = serde_json::from_slice::<InputDocument>(&payload).ok();
+            RagMatch {
+                id: doc
+                    .as_ref()
+                    .map(|doc| doc.id.clone())
+                    .unwrap_or_else(|| item.id),
                 score: item.score,
-                text: item
-                    .payload
-                    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
-                    .unwrap_or_default(),
-            })
-            .collect::<Vec<_>>();
+                text: doc
+                    .map(|doc| doc.text)
+                    .unwrap_or_else(|| String::from_utf8_lossy(&payload).into_owned()),
+            }
+        })
+        .collect::<Vec<_>>();
 
     let context = matches
         .iter()
@@ -172,6 +189,7 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
     serde_json::to_vec(&RagResponse {
         query: request.query,
         index: request.index,
+        effective_index,
         answer,
         matches,
         embedding_source,
@@ -265,6 +283,64 @@ fn fallback_answer(query: &str, matches: &[RagMatch]) -> String {
         "Best context for `{query}` is `{}` with score {:.3}: {}",
         best.id, best.score, best.text
     )
+}
+
+fn cleanup_temp_docs(
+    index: &str,
+    docs: &[bindings::tachyon::mesh::vector::Document],
+) -> Result<(), String> {
+    for doc in docs {
+        bindings::tachyon::mesh::vector::remove(index, &doc.id)
+            .map_err(|error| format!("vector cleanup failed for `{}`: {error}", doc.id))?;
+    }
+    Ok(())
+}
+
+fn effective_index_name(requested: &str, embedding_source: &str, dim: u32) -> String {
+    format!(
+        "demo-{}-{}-d{}",
+        sanitize_index_part(requested),
+        short_hash_hex(embedding_source.as_bytes()),
+        dim
+    )
+}
+
+fn request_doc_prefix(query: &str, index: &str, documents: &[InputDocument]) -> String {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(index.as_bytes());
+    bytes.extend_from_slice(query.as_bytes());
+    for doc in documents {
+        bytes.extend_from_slice(doc.id.as_bytes());
+        bytes.extend_from_slice(doc.text.as_bytes());
+    }
+    format!("req-{}", short_hash_hex(&bytes))
+}
+
+fn temp_doc_id(prefix: &str, doc_id: &str) -> String {
+    format!("{prefix}-{}", sanitize_index_part(doc_id))
+}
+
+fn sanitize_index_part(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    sanitized.trim_matches('-').to_owned()
+}
+
+fn short_hash_hex(bytes: &[u8]) -> String {
+    let mut hash = 14_695_981_039_346_656_037_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    format!("{hash:016x}")
 }
 
 fn deterministic_embedding(text: &str) -> Vec<f32> {

--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -9,52 +9,339 @@ mod bindings {
     export!(Component);
 }
 
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_INDEX: &str = "tenant-kb";
+const DEFAULT_EMBEDDING_MODEL: &str = "demo-embedding";
+const DEFAULT_CHAT_MODEL: &str = "demo-chat";
+const FALLBACK_EMBEDDING_DIM: u32 = 16;
+
 struct Component;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RagRequest {
+    query: String,
+    #[serde(default = "default_index")]
+    index: String,
+    #[serde(default = "default_top_k")]
+    top_k: u32,
+    #[serde(default)]
+    documents: Option<Vec<InputDocument>>,
+    #[serde(default = "default_embedding_model")]
+    embedding_model: String,
+    #[serde(default = "default_chat_model")]
+    chat_model: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct InputDocument {
+    id: String,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RagResponse {
+    query: String,
+    index: String,
+    answer: String,
+    matches: Vec<RagMatch>,
+    embedding_source: String,
+    completion_source: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RagMatch {
+    id: String,
+    score: f32,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingResponse {
+    data: Vec<OpenAiEmbeddingData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingData {
+    embedding: Vec<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatResponse {
+    choices: Vec<OpenAiChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiMessage {
+    content: String,
+}
 
 impl bindings::exports::tachyon::mesh::handler::Guest for Component {
     fn handle_request(
-        _req: bindings::exports::tachyon::mesh::handler::Request,
+        req: bindings::exports::tachyon::mesh::handler::Request,
     ) -> bindings::exports::tachyon::mesh::handler::Response {
-        let spec = bindings::tachyon::mesh::vector::IndexSpec {
-            name: "tenant-kb".to_owned(),
-            dim: 3,
-            m: 16,
-            ef_construction: 200,
-        };
-        let result = bindings::tachyon::mesh::vector::create_index(&spec)
-            .and_then(|_| {
-                bindings::tachyon::mesh::vector::upsert(
-                    "tenant-kb",
-                    &[bindings::tachyon::mesh::vector::Document {
-                        id: "doc-edge".to_owned(),
-                        embedding: vec![1.0, 0.0, 0.0],
-                        payload: Some(b"edge private context".to_vec()),
-                    }],
-                )
-            })
-            .and_then(|_| {
-                bindings::tachyon::mesh::vector::search("tenant-kb", &[0.9, 0.1, 0.0], 1)
-            });
-
-        match result {
-            Ok(matches) => response(
-                200,
-                matches
-                    .first()
-                    .and_then(|item| item.payload.as_ref())
-                    .cloned()
-                    .unwrap_or_else(|| b"no match".to_vec()),
-            ),
-            Err(error) => response(500, error.into_bytes()),
+        match handle_rag(req.body) {
+            Ok(body) => response(200, body),
+            Err(error) => response(400, json_error(&error)),
         }
     }
+}
+
+fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
+    let request: RagRequest =
+        serde_json::from_slice(&body).map_err(|error| format!("invalid RAG request: {error}"))?;
+    if request.query.trim().is_empty() {
+        return Err("query must not be empty".to_owned());
+    }
+    if request.top_k == 0 {
+        return Err("top_k must be greater than zero".to_owned());
+    }
+
+    let documents = request.documents.clone().unwrap_or_else(default_documents);
+    if documents.is_empty() {
+        return Err("documents must not be empty".to_owned());
+    }
+
+    let texts = documents
+        .iter()
+        .map(|doc| doc.text.as_str())
+        .chain(std::iter::once(request.query.as_str()))
+        .collect::<Vec<_>>();
+    let (mut embeddings, embedding_source) = embed_texts(&request.embedding_model, &texts);
+    let query_embedding = embeddings
+        .pop()
+        .ok_or_else(|| "embedding pipeline returned no query embedding".to_owned())?;
+
+    let _ = bindings::tachyon::mesh::vector::create_index(
+        &bindings::tachyon::mesh::vector::IndexSpec {
+            name: request.index.clone(),
+            dim: query_embedding.len() as u32,
+            m: 16,
+            ef_construction: 200,
+        },
+    );
+
+    let vector_docs = documents
+        .iter()
+        .zip(embeddings.iter())
+        .map(
+            |(doc, embedding)| bindings::tachyon::mesh::vector::Document {
+                id: doc.id.clone(),
+                embedding: embedding.clone(),
+                payload: Some(doc.text.as_bytes().to_vec()),
+            },
+        )
+        .collect::<Vec<_>>();
+    bindings::tachyon::mesh::vector::upsert(&request.index, &vector_docs)
+        .map_err(|error| format!("vector upsert failed: {error}"))?;
+
+    let matches =
+        bindings::tachyon::mesh::vector::search(&request.index, &query_embedding, request.top_k)
+            .map_err(|error| format!("vector search failed: {error}"))?
+            .into_iter()
+            .map(|item| RagMatch {
+                id: item.id,
+                score: item.score,
+                text: item
+                    .payload
+                    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                    .unwrap_or_default(),
+            })
+            .collect::<Vec<_>>();
+
+    let context = matches
+        .iter()
+        .map(|item| format!("- {}: {}", item.id, item.text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (answer, completion_source) =
+        complete_with_context(&request.chat_model, &request.query, &context).unwrap_or_else(|| {
+            (
+                fallback_answer(&request.query, &matches),
+                "local-fallback".to_owned(),
+            )
+        });
+
+    serde_json::to_vec(&RagResponse {
+        query: request.query,
+        index: request.index,
+        answer,
+        matches,
+        embedding_source,
+        completion_source,
+    })
+    .map_err(|error| format!("failed to encode RAG response: {error}"))
+}
+
+fn embed_texts(model: &str, texts: &[&str]) -> (Vec<Vec<f32>>, String) {
+    let body = serde_json::json!({
+        "model": model,
+        "input": texts,
+    })
+    .to_string()
+    .into_bytes();
+
+    if let Ok(response) = bindings::tachyon::mesh::outbound_http::send_request(
+        "POST",
+        "/ai/v1/embeddings",
+        &[("content-type".to_owned(), "application/json".to_owned())],
+        &body,
+    ) {
+        if response.status == 200 {
+            if let Ok(decoded) = serde_json::from_slice::<OpenAiEmbeddingResponse>(&response.body) {
+                let embeddings = decoded
+                    .data
+                    .into_iter()
+                    .map(|item| normalize_embedding(item.embedding))
+                    .collect::<Vec<_>>();
+                let dim = embeddings.first().map(Vec::len).unwrap_or_default();
+                if embeddings.len() == texts.len()
+                    && dim > 0
+                    && embeddings.iter().all(|embedding| embedding.len() == dim)
+                {
+                    return (embeddings, format!("openai-compatible:{model}"));
+                }
+            }
+        }
+    }
+
+    (
+        texts
+            .iter()
+            .map(|text| deterministic_embedding(text))
+            .collect(),
+        "local-deterministic-fallback".to_owned(),
+    )
+}
+
+fn complete_with_context(model: &str, query: &str, context: &str) -> Option<(String, String)> {
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Answer only from the supplied Tachyon Mesh context."
+            },
+            {
+                "role": "user",
+                "content": format!("Context:\n{context}\n\nQuestion: {query}")
+            }
+        ],
+        "max_tokens": 160
+    })
+    .to_string()
+    .into_bytes();
+
+    let response = bindings::tachyon::mesh::outbound_http::send_request(
+        "POST",
+        "/ai/v1/chat/completions",
+        &[("content-type".to_owned(), "application/json".to_owned())],
+        &body,
+    )
+    .ok()?;
+    if response.status != 200 {
+        return None;
+    }
+    let decoded = serde_json::from_slice::<OpenAiChatResponse>(&response.body).ok()?;
+    decoded
+        .choices
+        .into_iter()
+        .next()
+        .map(|choice| (choice.message.content, format!("openai-compatible:{model}")))
+}
+
+fn fallback_answer(query: &str, matches: &[RagMatch]) -> String {
+    let Some(best) = matches.first() else {
+        return format!("No context matched `{query}`.");
+    };
+    format!(
+        "Best context for `{query}` is `{}` with score {:.3}: {}",
+        best.id, best.score, best.text
+    )
+}
+
+fn deterministic_embedding(text: &str) -> Vec<f32> {
+    let mut values = vec![0.0_f32; FALLBACK_EMBEDDING_DIM as usize];
+    for token in text.split(|ch: char| !ch.is_alphanumeric()) {
+        if token.is_empty() {
+            continue;
+        }
+        let mut hash = 2_166_136_261_u32;
+        for byte in token.bytes() {
+            hash ^= u32::from(byte.to_ascii_lowercase());
+            hash = hash.wrapping_mul(16_777_619);
+        }
+        let idx = (hash as usize) % values.len();
+        values[idx] += 1.0;
+    }
+    normalize_embedding(values)
+}
+
+fn normalize_embedding(mut embedding: Vec<f32>) -> Vec<f32> {
+    let norm = embedding
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt();
+    if norm > 0.0 {
+        for value in &mut embedding {
+            *value /= norm;
+        }
+    }
+    embedding
+}
+
+fn default_documents() -> Vec<InputDocument> {
+    vec![
+        InputDocument {
+            id: "dispatch-locality".to_owned(),
+            text: "Tachyon Mesh can dispatch calls between sealed FaaS routes in-process when the target route is local and not saturated.".to_owned(),
+        },
+        InputDocument {
+            id: "vector-rag".to_owned(),
+            text: "The vector WIT interface creates indexes, upserts embeddings with payloads, and returns nearest matches for retrieval augmented generation.".to_owned(),
+        },
+        InputDocument {
+            id: "mcp-access".to_owned(),
+            text: "The tachyon_vector_search MCP tool is read-only and forwards an agent query to the RAG route with an index name and top_k limit.".to_owned(),
+        },
+    ]
+}
+
+fn json_error(error: &str) -> Vec<u8> {
+    serde_json::json!({ "error": error })
+        .to_string()
+        .into_bytes()
 }
 
 fn response(status: u16, body: Vec<u8>) -> bindings::exports::tachyon::mesh::handler::Response {
     bindings::exports::tachyon::mesh::handler::Response {
         status,
-        headers: Vec::new(),
+        headers: vec![("content-type".to_owned(), "application/json".to_owned())],
         body,
-        trailers: Vec::new(),
+        trailers: vec![],
     }
+}
+
+fn default_index() -> String {
+    DEFAULT_INDEX.to_owned()
+}
+
+fn default_embedding_model() -> String {
+    DEFAULT_EMBEDDING_MODEL.to_owned()
+}
+
+fn default_chat_model() -> String {
+    DEFAULT_CHAT_MODEL.to_owned()
+}
+
+fn default_top_k() -> u32 {
+    3
 }

--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -10,6 +10,7 @@ mod bindings {
 }
 
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const DEFAULT_INDEX: &str = "tenant-kb";
 const DEFAULT_EMBEDDING_MODEL: &str = "demo-embedding";
@@ -17,6 +18,8 @@ const DEFAULT_CHAT_MODEL: &str = "demo-chat";
 const FALLBACK_EMBEDDING_DIM: u32 = 16;
 
 struct Component;
+
+static LOCAL_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +35,8 @@ struct RagRequest {
     embedding_model: String,
     #[serde(default = "default_chat_model")]
     chat_model: String,
+    #[serde(default)]
+    request_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -119,12 +124,18 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
     let query_embedding = embeddings
         .pop()
         .ok_or_else(|| "embedding pipeline returned no query embedding".to_owned())?;
+    let request_id = request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| local_request_id(&request.query, &documents));
     let effective_index = effective_index_name(
         &request.index,
         &embedding_source,
         query_embedding.len() as u32,
+        &request_id,
     );
-    let request_prefix = request_doc_prefix(&request.query, &effective_index, &documents);
+    let request_prefix =
+        request_doc_prefix(&request_id, &request.query, &effective_index, &documents);
 
     let _ = bindings::tachyon::mesh::vector::create_index(
         &bindings::tachyon::mesh::vector::IndexSpec {
@@ -151,12 +162,15 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
     bindings::tachyon::mesh::vector::upsert(&effective_index, &vector_docs)
         .map_err(|error| format!("vector upsert failed: {error}"))?;
 
+    let search_top_k = request.top_k.saturating_add(vector_docs.len() as u32);
     let search_result =
-        bindings::tachyon::mesh::vector::search(&effective_index, &query_embedding, request.top_k);
+        bindings::tachyon::mesh::vector::search(&effective_index, &query_embedding, search_top_k);
     cleanup_temp_docs(&effective_index, &vector_docs)?;
     let matches = search_result
         .map_err(|error| format!("vector search failed: {error}"))?
         .into_iter()
+        .filter(|item| item.id.starts_with(&request_prefix))
+        .take(request.top_k as usize)
         .map(|item| {
             let payload = item.payload.unwrap_or_default();
             let doc = serde_json::from_slice::<InputDocument>(&payload).ok();
@@ -296,17 +310,29 @@ fn cleanup_temp_docs(
     Ok(())
 }
 
-fn effective_index_name(requested: &str, embedding_source: &str, dim: u32) -> String {
+fn effective_index_name(
+    requested: &str,
+    embedding_source: &str,
+    dim: u32,
+    request_id: &str,
+) -> String {
     format!(
-        "demo-{}-{}-d{}",
+        "demo-{}-{}-d{}-{}",
         sanitize_index_part(requested),
         short_hash_hex(embedding_source.as_bytes()),
-        dim
+        dim,
+        sanitize_index_part(request_id)
     )
 }
 
-fn request_doc_prefix(query: &str, index: &str, documents: &[InputDocument]) -> String {
+fn request_doc_prefix(
+    request_id: &str,
+    query: &str,
+    index: &str,
+    documents: &[InputDocument],
+) -> String {
     let mut bytes = Vec::new();
+    bytes.extend_from_slice(request_id.as_bytes());
     bytes.extend_from_slice(index.as_bytes());
     bytes.extend_from_slice(query.as_bytes());
     for doc in documents {
@@ -314,6 +340,17 @@ fn request_doc_prefix(query: &str, index: &str, documents: &[InputDocument]) -> 
         bytes.extend_from_slice(doc.text.as_bytes());
     }
     format!("req-{}", short_hash_hex(&bytes))
+}
+
+fn local_request_id(query: &str, documents: &[InputDocument]) -> String {
+    let counter = LOCAL_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut bytes = counter.to_le_bytes().to_vec();
+    bytes.extend_from_slice(query.as_bytes());
+    for doc in documents {
+        bytes.extend_from_slice(doc.id.as_bytes());
+        bytes.extend_from_slice(doc.text.as_bytes());
+    }
+    format!("local-{}", short_hash_hex(&bytes))
 }
 
 fn temp_doc_id(prefix: &str, doc_id: &str) -> String {

--- a/openspec/specs/embedded-core-store/spec.md
+++ b/openspec/specs/embedded-core-store/spec.md
@@ -40,9 +40,10 @@ The repository SHALL provide an `examples/guest-rag-vector` user FaaS example th
 
 #### Scenario: RAG guest indexes temporary documents and returns nearest context
 - **WHEN** `/api/guest-rag-vector` receives a JSON request with `query`, `index`, `topK`, and optional `documents`
-- **THEN** the guest derives an effective vector index name from the requested index, embedding source, and embedding dimension
+- **THEN** the guest derives an effective vector index name from the requested index, embedding source, embedding dimension, and request identifier
 - **AND** upserts request-local document embeddings with payload text
-- **AND** searches the index with the query embedding
+- **AND** searches the request-specific index with the query embedding
+- **AND** filters returned vector IDs to the current request prefix before building matches
 - **AND** removes the request-local document IDs from the index before returning
 - **AND** returns `matches` containing document IDs, scores, and payload text
 

--- a/openspec/specs/embedded-core-store/spec.md
+++ b/openspec/specs/embedded-core-store/spec.md
@@ -35,3 +35,24 @@ The Mesh SHALL expose a `wit/store/vector.wit` interface in the Wasm Component M
 - **AND** returns the matching IDs and scores to the guest
 - **AND** the index data remains isolated from other tenants according to the optional TDE policy
 
+### Requirement: Repository provides an end-to-end RAG vector guest example
+The repository SHALL provide an `examples/guest-rag-vector` user FaaS example that demonstrates document ingestion, embedding generation, vector upsert/search through `tachyon:mesh/vector`, and answer generation with retrieved context. The example SHALL try the OpenAI-compatible `/ai/v1/embeddings` and `/ai/v1/chat/completions` routes through scoped outbound HTTP when they are available, and SHALL provide deterministic local fallbacks so the route remains smoke-testable without a loaded model.
+
+#### Scenario: RAG guest indexes documents and returns nearest context
+- **WHEN** `/api/guest-rag-vector` receives a JSON request with `query`, `index`, `topK`, and optional `documents`
+- **THEN** the guest creates or reuses the named vector index
+- **AND** upserts document embeddings with payload text
+- **AND** searches the index with the query embedding
+- **AND** returns `matches` containing document IDs, scores, and payload text
+
+#### Scenario: RAG guest uses OpenAI-compatible routes when available
+- **GIVEN** the route's deployment scopes grant outbound HTTP access to `/ai/v1/embeddings` and `/ai/v1/chat/completions`
+- **WHEN** those routes return successful OpenAI-compatible responses
+- **THEN** `guest-rag-vector` uses their embeddings and completion content
+- **AND** the response identifies the OpenAI-compatible embedding and completion sources
+
+#### Scenario: RAG guest falls back without a loaded model
+- **GIVEN** the OpenAI-compatible routes are absent, unavailable, or return unusable payloads
+- **WHEN** `/api/guest-rag-vector` handles a request
+- **THEN** it computes deterministic local embeddings
+- **AND** returns a fallback answer grounded in the best retrieved match

--- a/openspec/specs/embedded-core-store/spec.md
+++ b/openspec/specs/embedded-core-store/spec.md
@@ -38,11 +38,12 @@ The Mesh SHALL expose a `wit/store/vector.wit` interface in the Wasm Component M
 ### Requirement: Repository provides an end-to-end RAG vector guest example
 The repository SHALL provide an `examples/guest-rag-vector` user FaaS example that demonstrates document ingestion, embedding generation, vector upsert/search through `tachyon:mesh/vector`, and answer generation with retrieved context. The example SHALL try the OpenAI-compatible `/ai/v1/embeddings` and `/ai/v1/chat/completions` routes through scoped outbound HTTP when they are available, and SHALL provide deterministic local fallbacks so the route remains smoke-testable without a loaded model.
 
-#### Scenario: RAG guest indexes documents and returns nearest context
+#### Scenario: RAG guest indexes temporary documents and returns nearest context
 - **WHEN** `/api/guest-rag-vector` receives a JSON request with `query`, `index`, `topK`, and optional `documents`
-- **THEN** the guest creates or reuses the named vector index
-- **AND** upserts document embeddings with payload text
+- **THEN** the guest derives an effective vector index name from the requested index, embedding source, and embedding dimension
+- **AND** upserts request-local document embeddings with payload text
 - **AND** searches the index with the query embedding
+- **AND** removes the request-local document IDs from the index before returning
 - **AND** returns `matches` containing document IDs, scores, and payload text
 
 #### Scenario: RAG guest uses OpenAI-compatible routes when available

--- a/openspec/specs/faas-package-import/spec.md
+++ b/openspec/specs/faas-package-import/spec.md
@@ -38,6 +38,21 @@ pretty-printed JSON.
 - **WHEN** an MCP client calls `tachyon_import_package` with a valid `package_path`
 - **THEN** the tool delegates to `tachyon_client::import_faas_package` and returns `{ content: [{ type: "text", text: <json> }] }`
 
+### Requirement: RAG vector example is importable as a FaaS package
+The repository SHALL provide a package manifest for `examples/guest-rag-vector` that can be bundled with its compiled WASM artifact and imported through `tachyon_import_package`. The manifest SHALL declare `/api/guest-rag-vector` as a user route backed by the `guest-rag-vector` module, with explicit `vector` scope for its demo indexes and explicit `http` scope for the OpenAI-compatible embedding and chat completion routes.
+
+#### Scenario: Operator imports the RAG vector example package
+- **WHEN** an operator imports a package containing `guest-rag-vector.wasm` and `examples/guest-rag-vector/manifest.json`
+- **THEN** the import maps the manifest's `guest-rag-vector` module reference to the uploaded WASM asset URI
+- **AND** the live manifest gains the `/api/guest-rag-vector` route
+- **AND** the route has `vector` and `http` scopes sufficient to run the documented RAG demo
+
+#### Scenario: Imported RAG route is agent-queryable
+- **GIVEN** `/api/guest-rag-vector` has been imported and applied
+- **WHEN** an MCP agent calls `tachyon_vector_search` without specifying `route_path`
+- **THEN** the MCP tool queries `/api/guest-rag-vector`
+- **AND** returns the route's RAG response to the agent
+
 ### Requirement: Tauri command and Workloads UI for package import
 The system SHALL provide a `import_faas_package(bytes: Vec<u8>)` Tauri command
 and an *Import & Deploy* section in `TachyonWorkloadsPanel` that lets the

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -180,6 +180,25 @@ The MCP server SHALL expose LLM inference KV-cache administration tools backed b
 - **WHEN** `tachyon_kv_cache_flush` exhausts its per-minute mutator bucket
 - **THEN** further calls return the structured rate-limit error (`-32002`) with `retry_after_ms`
 
+### Requirement: MCP exposes read-only vector search for RAG agents
+The MCP server SHALL expose a `tachyon_vector_search` JSON-RPC tool for agent-facing RAG queries. The tool SHALL require `query`, `index`, and `top_k`, SHALL accept optional `route_path`, `embedding_model`, `chat_model`, and request-local `documents`, and SHALL delegate through `tachyon_client::vector_search` to a configured Tachyon route that implements the RAG/vector HTTP contract. The default route SHALL be `/api/guest-rag-vector`, overridable per call via `route_path` or per process via `TACHYON_MCP_VECTOR_SEARCH_PATH`. The tool SHALL be read-only from MCP's perspective and SHALL use the read-oriented rate-limit bucket.
+
+#### Scenario: Agent calls vector search with required arguments
+- **WHEN** an MCP client calls `tachyon_vector_search` with `query`, `index`, and `top_k`
+- **THEN** the server forwards those values to `tachyon_client::vector_search`
+- **AND** the client posts the request to `/api/guest-rag-vector` unless an override route is configured
+- **AND** the tool returns the route's JSON response as text tool content
+
+#### Scenario: Missing vector search arguments are rejected before cluster dispatch
+- **WHEN** a `tachyon_vector_search` call omits `query`, `index`, or `top_k`
+- **THEN** the MCP server returns an invalid-params error (`-32602`)
+- **AND** it does not contact the cluster
+
+#### Scenario: Vector search is rate-limited as a read-only tool
+- **WHEN** `tachyon_vector_search` is called within its read-oriented per-minute budget
+- **THEN** the request is permitted independently from mutator tool buckets
+- **AND** exceeding the read bucket returns the structured rate-limit error (`-32002`) with `retry_after_ms`
+
 ### Requirement: tachyon-mcp MUST have a stdio E2E test harness
 A Rust integration test at `tachyon-mcp/tests/mcp_e2e_runner.rs` SHALL spawn the compiled `tachyon-mcp` binary, drive it via stdin/stdout, and assert that: (1) `initialize` returns the correct MCP protocol version; (2) `tools/list` returns a structurally valid JSON-RPC response; (3) with a live cluster, the core tools are present and read-only calls do not return `-32603`.
 

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -181,12 +181,13 @@ The MCP server SHALL expose LLM inference KV-cache administration tools backed b
 - **THEN** further calls return the structured rate-limit error (`-32002`) with `retry_after_ms`
 
 ### Requirement: MCP exposes read-only vector search for RAG agents
-The MCP server SHALL expose a `tachyon_vector_search` JSON-RPC tool for agent-facing RAG queries. The tool SHALL require `query`, `index`, and `top_k`, SHALL accept optional `route_path`, `embedding_model`, `chat_model`, and request-local `documents`, and SHALL delegate through `tachyon_client::vector_search` to a configured Tachyon route that implements the RAG/vector HTTP contract. The default route SHALL be `/api/guest-rag-vector`, overridable per call via `route_path` or per process via `TACHYON_MCP_VECTOR_SEARCH_PATH`. The tool SHALL be read-only from MCP's perspective and SHALL use the read-oriented rate-limit bucket.
+The MCP server SHALL expose a `tachyon_vector_search` JSON-RPC tool for agent-facing RAG queries. The tool SHALL require `query`, `index`, and `top_k`, SHALL accept optional `route_path`, `embedding_model`, `chat_model`, and request-local `documents`, and SHALL delegate through `tachyon_client::vector_search` to a configured Tachyon route that implements the RAG/vector HTTP contract. The default route SHALL be `/api/guest-rag-vector`, overridable per call via `route_path` or per process via `TACHYON_MCP_VECTOR_SEARCH_PATH`. The delegated client request SHALL include an internal request identifier so temporary RAG vector documents are isolated per tool call. The tool SHALL be read-only from MCP's perspective and SHALL use the read-oriented rate-limit bucket.
 
 #### Scenario: Agent calls vector search with required arguments
 - **WHEN** an MCP client calls `tachyon_vector_search` with `query`, `index`, and `top_k`
 - **THEN** the server forwards those values to `tachyon_client::vector_search`
 - **AND** the client posts the request to `/api/guest-rag-vector` unless an override route is configured
+- **AND** the posted payload carries a per-call request identifier
 - **AND** the tool returns the route's JSON response as text tool content
 
 #### Scenario: Missing vector search arguments are rejected before cluster dispatch

--- a/tachyon-client/src/lib.rs
+++ b/tachyon-client/src/lib.rs
@@ -9,7 +9,10 @@ use std::{
     io::{ErrorKind, Read, Write},
     net::IpAddr,
     path::PathBuf,
-    sync::{OnceLock, RwLock},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        OnceLock, RwLock,
+    },
 };
 use sysinfo::System;
 
@@ -62,6 +65,7 @@ pub struct InstanceConfig {
 static CONNECTION_STATE: OnceLock<RwLock<Option<InstanceConfig>>> = OnceLock::new();
 static SESSION_OPERATOR: OnceLock<RwLock<Option<String>>> = OnceLock::new();
 static HTTP_CLIENT_CACHE: OnceLock<RwLock<BTreeMap<String, reqwest::Client>>> = OnceLock::new();
+static VECTOR_SEARCH_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -656,6 +660,8 @@ pub struct VectorSearchRequest {
     pub embedding_model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2384,7 +2390,20 @@ pub async fn vector_search(
     } else {
         route_path.trim()
     };
-    post_admin_json(path, request).await
+    let mut request = request.clone();
+    if request.request_id.is_none() {
+        request.request_id = Some(vector_search_request_id());
+    }
+    post_admin_json(path, &request).await
+}
+
+fn vector_search_request_id() -> String {
+    let counter = VECTOR_SEARCH_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{nanos}-{counter}", std::process::id())
 }
 
 /// List deployed functions (routes) by reading the live mesh graph.
@@ -4803,6 +4822,16 @@ mod tests {
         assert_eq!(stats.total_bytes, 2048);
         assert_eq!(stats.expired_count, 1);
         assert_eq!(stats.hit_rate, None);
+    }
+
+    #[test]
+    fn vector_search_request_ids_are_unique() {
+        let first = vector_search_request_id();
+        let second = vector_search_request_id();
+
+        assert_ne!(first, second);
+        assert!(!first.trim().is_empty());
+        assert!(!second.trim().is_empty());
     }
 
     #[test]

--- a/tachyon-client/src/lib.rs
+++ b/tachyon-client/src/lib.rs
@@ -646,6 +646,28 @@ pub struct KvCacheFlushOutcome {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct VectorSearchRequest {
+    pub query: String,
+    pub index: String,
+    pub top_k: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub documents: Option<Vec<VectorSearchDocument>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VectorSearchDocument {
+    pub id: String,
+    pub text: String,
+}
+
+pub type VectorSearchResponse = serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LogLine {
     pub timestamp: String,
     pub level: String,
@@ -2340,6 +2362,30 @@ pub async fn kv_cache_flush(model: &str) -> Result<KvCacheFlushOutcome> {
 }
 
 // ── WASM function lifecycle ───────────────────────────────────────────────────
+
+/// Query a read-only RAG/vector search route. By default this calls the
+/// `examples/guest-rag-vector` route and lets the guest perform WIT vector
+/// lookup plus optional OpenAI-compatible completion.
+pub async fn vector_search(
+    route_path: &str,
+    request: &VectorSearchRequest,
+) -> Result<VectorSearchResponse> {
+    if request.query.trim().is_empty() {
+        anyhow::bail!("vector search query must not be empty");
+    }
+    if request.index.trim().is_empty() {
+        anyhow::bail!("vector search index must not be empty");
+    }
+    if request.top_k == 0 {
+        anyhow::bail!("vector search top_k must be greater than zero");
+    }
+    let path = if route_path.trim().is_empty() {
+        "/api/guest-rag-vector"
+    } else {
+        route_path.trim()
+    };
+    post_admin_json(path, request).await
+}
 
 /// List deployed functions (routes) by reading the live mesh graph.
 pub async fn list_functions() -> Result<Vec<MeshRouteSummary>> {

--- a/tachyon-mcp/src/main.rs
+++ b/tachyon-mcp/src/main.rs
@@ -294,6 +294,7 @@ fn missing_required_args(tool_name: &str, arguments: Option<&Value>) -> Option<V
         "tachyon_kv_put" => &["namespace", "key", "value"],
         "tachyon_kv_delete" => &["namespace", "key"],
         "tachyon_kv_cache_stats" | "tachyon_kv_cache_flush" => &["model"],
+        "tachyon_vector_search" => &["query", "index", "top_k"],
         "tachyon_canary_split" => &["route_path", "weight_pct"],
         "tachyon_register_resource" => &["name", "type", "target"],
         "tachyon_dryrun_manifest" => &["manifest"],
@@ -371,6 +372,7 @@ fn rate_limit_spec(tool_name: &str) -> Option<RateLimitSpec> {
         | "tachyon_lora_training_status"
         | "tachyon_kv_get"
         | "tachyon_kv_cache_stats"
+        | "tachyon_vector_search"
         | "tachyon_dryrun_manifest"
         | "validate_faas_capabilities"
         | "run_chaos_scenario"
@@ -736,7 +738,7 @@ async fn handle_line(line: &str, context: &McpContext) -> Result<Option<Value>> 
                             },
                             "scopes": {
                                 "type": "object",
-                                "description": "Scopes block to merge. Keys are WIT categories (secrets, kv, graph, sql, http_client, blob, messaging, crypto, routing, compute); values are arrays of glob patterns or 'allow-all'."
+                                "description": "Scopes block to merge. Keys are WIT categories (secrets, kv, graph, sql, http, blob, messaging, crypto, routing, compute); values are arrays of glob patterns or 'allow-all'."
                             },
                             "dry_run": {
                                 "type": "boolean",
@@ -982,6 +984,34 @@ async fn handle_line(line: &str, context: &McpContext) -> Result<Option<Value>> 
                         "required": ["model"],
                         "properties": {
                             "model": { "type": "string", "description": "Model reference declared in IntegrityConfig.kv_caches[].model_ref." }
+                        }
+                    }
+                },
+                {
+                    "name": "tachyon_vector_search",
+                    "description": "Read-only RAG/vector query. Forwards query, index, and top_k to the configured vector-search route (default /api/guest-rag-vector), returning nearest context and the route's answer without mutating MCP state.",
+                    "inputSchema": {
+                        "type": "object",
+                        "required": ["query", "index", "top_k"],
+                        "properties": {
+                            "query": { "type": "string", "description": "Natural-language query to embed and search." },
+                            "index": { "type": "string", "description": "Vector index name, for example `tenant-kb`." },
+                            "top_k": { "type": "integer", "minimum": 1, "maximum": 50, "description": "Maximum number of nearest matches to return." },
+                            "route_path": { "type": "string", "default": "/api/guest-rag-vector", "description": "Optional Tachyon route that implements the RAG/vector HTTP contract." },
+                            "embedding_model": { "type": "string", "description": "Optional OpenAI-compatible embedding model alias passed to the route." },
+                            "chat_model": { "type": "string", "description": "Optional OpenAI-compatible chat model alias passed to the route." },
+                            "documents": {
+                                "type": "array",
+                                "description": "Optional demo documents to ingest before search. Each item has id and text.",
+                                "items": {
+                                    "type": "object",
+                                    "required": ["id", "text"],
+                                    "properties": {
+                                        "id": { "type": "string" },
+                                        "text": { "type": "string" }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -1675,7 +1705,7 @@ async fn handle_tool_dispatch(name: &str, params: Option<&Value>) -> Result<Valu
                 (
                     Some(
                         "# Conservative starting point — tighten patterns after observing runtime behaviour\n\
-                         scopes:\n  secrets: [\"**\"]\n  kv: [\"**\"]\n  http_client: [\"**\"]\n\
+                         scopes:\n  secrets: [\"**\"]\n  kv: [\"**\"]\n  http: [\"**\"]\n\
                          # Remove categories your function does not use"
                             .to_string(),
                     ),
@@ -1952,6 +1982,56 @@ async fn handle_tool_dispatch(name: &str, params: Option<&Value>) -> Result<Valu
             Ok(text_tool_result(&outcome)?)
         }
 
+        // ── Vector/RAG search ─────────────────────────────────────────────────
+        "tachyon_vector_search" => {
+            let arguments = params
+                .and_then(|v| v.get("arguments"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let query = arguments
+                .get("query")
+                .and_then(Value::as_str)
+                .context("missing query")?
+                .to_owned();
+            let index = arguments
+                .get("index")
+                .and_then(Value::as_str)
+                .context("missing index")?
+                .to_owned();
+            let top_k = arguments
+                .get("top_k")
+                .and_then(Value::as_u64)
+                .context("missing top_k")?
+                .min(50) as u32;
+            let route_path = arguments
+                .get("route_path")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or_else(|| env::var("TACHYON_MCP_VECTOR_SEARCH_PATH").ok())
+                .unwrap_or_else(|| "/api/guest-rag-vector".to_owned());
+            let documents = arguments
+                .get("documents")
+                .cloned()
+                .map(serde_json::from_value)
+                .transpose()
+                .context("invalid documents payload")?;
+            let request = tachyon_client::VectorSearchRequest {
+                query,
+                index,
+                top_k,
+                documents,
+                embedding_model: arguments
+                    .get("embedding_model")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+                chat_model: arguments
+                    .get("chat_model")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+            };
+            let result = tachyon_client::vector_search(&route_path, &request).await?;
+            Ok(text_tool_result(&result)?)
+        }
         // ── Canary traffic split ──────────────────────────────────────────────
         "tachyon_canary_split" => {
             let arguments = params
@@ -2465,6 +2545,27 @@ mod tests {
         assert_eq!(flush.limit, 30);
     }
 
+    #[test]
+    fn vector_search_required_args_and_rate_limit_match_spec() {
+        assert_eq!(
+            missing_required_args("tachyon_vector_search", Some(&json!({}))),
+            Some(vec![
+                "query".to_owned(),
+                "index".to_owned(),
+                "top_k".to_owned()
+            ])
+        );
+        assert!(missing_required_args(
+            "tachyon_vector_search",
+            Some(&json!({"query": "q", "index": "tenant-kb", "top_k": 3}))
+        )
+        .is_none());
+
+        let spec =
+            rate_limit_spec("tachyon_vector_search").expect("vector search must have a rate limit");
+        assert_eq!(spec.limit, 100);
+    }
+
     #[tokio::test]
     async fn tools_list_includes_kv_cache_admin_tools() {
         let context = McpContext::new_for_tests(test_state_path("tools-list-kv-cache"));
@@ -2486,6 +2587,7 @@ mod tests {
 
         assert!(names.contains(&"tachyon_kv_cache_stats"));
         assert!(names.contains(&"tachyon_kv_cache_flush"));
+        assert!(names.contains(&"tachyon_vector_search"));
     }
 
     #[tokio::test]

--- a/tachyon-mcp/src/main.rs
+++ b/tachyon-mcp/src/main.rs
@@ -2028,6 +2028,7 @@ async fn handle_tool_dispatch(name: &str, params: Option<&Value>) -> Result<Valu
                     .get("chat_model")
                     .and_then(Value::as_str)
                     .map(str::to_owned),
+                request_id: None,
             };
             let result = tachyon_client::vector_search(&route_path, &request).await?;
             Ok(text_tool_result(&result)?)


### PR DESCRIPTION
## Summary

- expand `examples/guest-rag-vector` into an end-to-end RAG demo covering ingestion, embeddings, vector upsert/search, and completion with retrieved context
- add the read-only `tachyon_vector_search` MCP tool and shared `tachyon_client::vector_search` helper
- document the RAG demo and update OpenSpec requirements for MCP, embedded vector store, and package import

## Validation

- `cargo fmt --package guest-rag-vector --package tachyon-client --package tachyon-mcp`
- `cargo check -p guest-rag-vector`
- `cargo check -p tachyon-client -p tachyon-mcp`
- `cargo test -p tachyon-mcp vector_search_required_args_and_rate_limit_match_spec`
- `cargo test -p tachyon-mcp tools_list_includes_kv_cache_admin_tools`
- `openspec validate mcp-server`
- `openspec validate embedded-core-store`
- `openspec validate faas-package-import`
- `git diff --check`

Fixes #313