### PR TITLE
Remove request_id from index name generation

### DIFF
--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -133,6 +133,7 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
         &request.index,
         &embedding_source,
         query_embedding.len() as u32,
+        &request_id,
     );
     let request_prefix =
         request_doc_prefix(&request_id, &request.query, &effective_index, &documents);
@@ -310,12 +311,23 @@ fn cleanup_temp_docs(
     Ok(())
 }
 
-fn effective_index_name(requested: &str, embedding_source: &str, dim: u32) -> String {
+fn effective_index_name(
+    requested: &str,
+    embedding_source: &str,
+    dim: u32,
+    request_id: &str,
+) -> String {
+    // A stable index shared across concurrent calls is unsafe: the host's
+    // vector store does a non-atomic read-modify-write on upsert/remove and
+    // caps search results at 100 globally, so concurrent requests can lose
+    // each other's documents or crowd each other out of the result set.
+    // Keeping request_id here isolates each call into its own index.
     format!(
-        "demo-{}-{}-d{}",
+        "demo-{}-{}-d{}-{}",
         sanitize_index_part(requested),
         short_hash_hex(embedding_source.as_bytes()),
         dim,
+        sanitize_index_part(request_id)
     )
 }
 

--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -10,6 +10,8 @@ mod bindings {
 }
 
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -349,13 +351,19 @@ fn request_doc_prefix(
 }
 
 fn local_request_id(query: &str, documents: &[InputDocument]) -> String {
+    // Each request runs in a freshly instantiated component, so this counter
+    // restarts at 1 every time and the wall clock alone can tie under
+    // concurrent load; mix in OS-backed randomness (WASI random_get via
+    // RandomState) so two concurrent requests never derive the same id.
     let counter = LOCAL_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
+    let entropy = RandomState::new().build_hasher().finish();
     let mut bytes = counter.to_le_bytes().to_vec();
     bytes.extend_from_slice(&nanos.to_le_bytes());
+    bytes.extend_from_slice(&entropy.to_le_bytes());
     bytes.extend_from_slice(query.as_bytes());
     for doc in documents {
         bytes.extend_from_slice(doc.id.as_bytes());

--- a/examples/guest-rag-vector/src/lib.rs
+++ b/examples/guest-rag-vector/src/lib.rs
@@ -11,6 +11,7 @@ mod bindings {
 
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const DEFAULT_INDEX: &str = "tenant-kb";
 const DEFAULT_EMBEDDING_MODEL: &str = "demo-embedding";
@@ -132,7 +133,6 @@ fn handle_rag(body: Vec<u8>) -> Result<Vec<u8>, String> {
         &request.index,
         &embedding_source,
         query_embedding.len() as u32,
-        &request_id,
     );
     let request_prefix =
         request_doc_prefix(&request_id, &request.query, &effective_index, &documents);
@@ -310,18 +310,12 @@ fn cleanup_temp_docs(
     Ok(())
 }
 
-fn effective_index_name(
-    requested: &str,
-    embedding_source: &str,
-    dim: u32,
-    request_id: &str,
-) -> String {
+fn effective_index_name(requested: &str, embedding_source: &str, dim: u32) -> String {
     format!(
-        "demo-{}-{}-d{}-{}",
+        "demo-{}-{}-d{}",
         sanitize_index_part(requested),
         short_hash_hex(embedding_source.as_bytes()),
         dim,
-        sanitize_index_part(request_id)
     )
 }
 
@@ -344,7 +338,12 @@ fn request_doc_prefix(
 
 fn local_request_id(query: &str, documents: &[InputDocument]) -> String {
     let counter = LOCAL_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
     let mut bytes = counter.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&nanos.to_le_bytes());
     bytes.extend_from_slice(query.as_bytes());
     for doc in documents {
         bytes.extend_from_slice(doc.id.as_bytes());


### PR DESCRIPTION
## Summary
This change refactors the index name generation logic to remove the request ID from the index name, while improving the request ID generation to include timestamp information for better uniqueness guarantees.

## Key Changes
- **Removed request_id parameter** from `effective_index_name()` function signature and its call site
- **Simplified index name format** from `demo-{}-{}-d{}-{}` to `demo-{}-{}-d{}` by removing the sanitized request_id component
- **Enhanced request ID generation** in `local_request_id()` to include nanosecond-precision timestamp alongside the atomic counter for improved uniqueness

## Implementation Details
The request ID generation now combines:
1. An atomic counter (`LOCAL_REQUEST_COUNTER`) for sequence tracking
2. Current system time in nanoseconds since UNIX_EPOCH for temporal uniqueness
3. Query string and document IDs for content-based differentiation

This approach decouples the index naming scheme from request-specific identifiers while maintaining request uniqueness through the enhanced ID generation logic.

https://claude.ai/code/session_0194qrDU3UgzPz7AnhVNk9K3