### PR TITLE
Gate AI_MODELS_SHADOWED_UPLOADS_TABLE behind ai-inference feature

### DIFF
--- a/core-host/src/system_storage.rs
+++ b/core-host/src/system_storage.rs
@@ -52,6 +52,7 @@ const AI_MODELS_REGISTRY_TABLE: &str = "ai-models-registry";
 /// Upload-owned rows displaced by a non-dynamic manifest binding. A configured
 /// alias executes the manifest backend while present, but the upload remains
 /// on disk and must become discoverable again when that ownership ends.
+#[cfg(feature = "ai-inference")]
 const AI_MODELS_SHADOWED_UPLOADS_TABLE: &str = "ai-models-shadowed-uploads";
 
 struct ComponentRequest {


### PR DESCRIPTION
Its only uses live inside publish_configured_model_bindings, which is already #[cfg(feature = "ai-inference")]. The core-host feature-matrix CI job builds each other feature in isolation with -D dead_code, which fails without this since the constant becomes unused.