### PR TITLE
Defer streaming-response telemetry to body completion, not handler return

### DIFF
--- a/core-host/src/host_core.rs
+++ b/core-host/src/host_core.rs
@@ -98,8 +98,8 @@ pub(crate) use std::{
     time::{Duration, Instant, SystemTime},
 };
 pub(crate) use telemetry::{
-    push_custom_metric, CustomMetric, CustomMetricType, TelemetryEvent, TelemetryHandle,
-    TelemetrySnapshot,
+    push_custom_metric, CustomMetric, CustomMetricType, RequestCompletion, TelemetryEvent,
+    TelemetryHandle, TelemetrySnapshot,
 };
 #[cfg(unix)]
 pub(crate) use tokio::net::UnixListener;

--- a/core-host/src/host_core/app_runtime.rs
+++ b/core-host/src/host_core/app_runtime.rs
@@ -841,6 +841,7 @@ pub(crate) fn build_guest_response(
         Some(trailers)
     };
 
+    let is_streaming = matches!(response.body, RouteResponseBody::Streaming(_));
     let body = match response.body {
         RouteResponseBody::Buffered(bytes) => {
             Body::new(GuestResponseBody::new(bytes, trailer_map, completion_guard))
@@ -857,6 +858,9 @@ pub(crate) fn build_guest_response(
         .body(body)
         .map_err(|error| format!("failed to construct guest HTTP response: {error}"))?;
     built.headers_mut().extend(response_headers);
+    if is_streaming {
+        built.extensions_mut().insert(StreamingResponseMarker);
+    }
     Ok(built)
 }
 
@@ -929,6 +933,7 @@ pub(crate) async fn forward_request_to_override(
         }
         built.headers_mut().append(name.clone(), value.clone());
     }
+    built.extensions_mut().insert(StreamingResponseMarker);
     Ok(built)
 }
 
@@ -1550,7 +1555,7 @@ pub(crate) async fn faas_handler(
     let trailers = collected.trailers().cloned().unwrap_or_default();
     let body = collected.to_bytes();
     let trailer_fields = header_map_to_guest_fields(&trailers);
-    let _active_request = telemetry::begin_request(&state.telemetry);
+    let active_request = telemetry::begin_request(&state.telemetry);
     let runtime = state.runtime.load_full();
     let normalized_path = normalize_route_path(uri.path());
     if is_reserved_system_path(&normalized_path) {
@@ -1746,15 +1751,20 @@ pub(crate) async fn faas_handler(
                             )
                         } else {
                             #[cfg(feature = "ai-inference")]
-                            if is_streaming_accept_request(&headers) {
-                                let request = GuestRequest {
+                            let streaming_route =
+                                is_streaming_accept_request(&headers).then(|| GuestRequest {
                                     method: method.to_string(),
                                     uri: uri.to_string(),
                                     headers: header_map_to_guest_fields(&headers),
                                     body: body.clone(),
                                     trailers: trailer_fields.clone(),
-                                };
-                                return match network::handle_streaming_http_request(
+                                });
+                            #[cfg(not(feature = "ai-inference"))]
+                            let streaming_route: Option<()> = None;
+
+                            match streaming_route {
+                                #[cfg(feature = "ai-inference")]
+                                Some(request) => match network::handle_streaming_http_request(
                                     state.clone(),
                                     Arc::clone(&runtime),
                                     Arc::clone(&route),
@@ -1766,32 +1776,38 @@ pub(crate) async fn faas_handler(
                                 )
                                 .await
                                 {
-                                    Ok(response) => response,
-                                    Err((status, message)) => (status, message).into_response(),
-                                };
-                            }
-                            match execute_route_arc_with_middleware(
-                                &state,
-                                &runtime,
-                                Arc::clone(&route),
-                                &headers,
-                                &method,
-                                &uri,
-                                &body,
-                                &trailer_fields,
-                                hop_limit,
-                                Some(&trace_id),
-                                sampled_execution,
-                                Some(selected_target.module.as_str()),
-                                true,
-                            )
-                            .await
-                            {
-                                Ok(result) => {
-                                    let fuel_consumed = result.fuel_consumed;
-                                    (guest_response_into_response(result), fuel_consumed)
-                                }
-                                Err((status, message)) => ((status, message).into_response(), None),
+                                    Ok(response) => (response, None),
+                                    Err((status, message)) => {
+                                        ((status, message).into_response(), None)
+                                    }
+                                },
+                                #[cfg(not(feature = "ai-inference"))]
+                                Some(()) => unreachable!(),
+                                None => match execute_route_arc_with_middleware(
+                                    &state,
+                                    &runtime,
+                                    Arc::clone(&route),
+                                    &headers,
+                                    &method,
+                                    &uri,
+                                    &body,
+                                    &trailer_fields,
+                                    hop_limit,
+                                    Some(&trace_id),
+                                    sampled_execution,
+                                    Some(selected_target.module.as_str()),
+                                    true,
+                                )
+                                .await
+                                {
+                                    Ok(result) => {
+                                        let fuel_consumed = result.fuel_consumed;
+                                        (guest_response_into_response(result), fuel_consumed)
+                                    }
+                                    Err((status, message)) => {
+                                        ((status, message).into_response(), None)
+                                    }
+                                },
                             }
                         }
                     }
@@ -1829,15 +1845,20 @@ pub(crate) async fn faas_handler(
                             )
                         } else {
                             #[cfg(feature = "ai-inference")]
-                            if is_streaming_accept_request(&headers) {
-                                let request = GuestRequest {
+                            let streaming_route =
+                                is_streaming_accept_request(&headers).then(|| GuestRequest {
                                     method: method.to_string(),
                                     uri: uri.to_string(),
                                     headers: header_map_to_guest_fields(&headers),
                                     body: body.clone(),
                                     trailers: trailer_fields.clone(),
-                                };
-                                return match network::handle_streaming_http_request(
+                                });
+                            #[cfg(not(feature = "ai-inference"))]
+                            let streaming_route: Option<()> = None;
+
+                            match streaming_route {
+                                #[cfg(feature = "ai-inference")]
+                                Some(request) => match network::handle_streaming_http_request(
                                     state.clone(),
                                     Arc::clone(&runtime),
                                     Arc::clone(&route),
@@ -1849,32 +1870,38 @@ pub(crate) async fn faas_handler(
                                 )
                                 .await
                                 {
-                                    Ok(response) => response,
-                                    Err((status, message)) => (status, message).into_response(),
-                                };
-                            }
-                            match execute_route_arc_with_middleware(
-                                &state,
-                                &runtime,
-                                Arc::clone(&route),
-                                &headers,
-                                &method,
-                                &uri,
-                                &body,
-                                &trailer_fields,
-                                hop_limit,
-                                Some(&trace_id),
-                                sampled_execution,
-                                Some(selected_target.module.as_str()),
-                                true,
-                            )
-                            .await
-                            {
-                                Ok(result) => {
-                                    let fuel_consumed = result.fuel_consumed;
-                                    (guest_response_into_response(result), fuel_consumed)
-                                }
-                                Err((status, message)) => ((status, message).into_response(), None),
+                                    Ok(response) => (response, None),
+                                    Err((status, message)) => {
+                                        ((status, message).into_response(), None)
+                                    }
+                                },
+                                #[cfg(not(feature = "ai-inference"))]
+                                Some(()) => unreachable!(),
+                                None => match execute_route_arc_with_middleware(
+                                    &state,
+                                    &runtime,
+                                    Arc::clone(&route),
+                                    &headers,
+                                    &method,
+                                    &uri,
+                                    &body,
+                                    &trailer_fields,
+                                    hop_limit,
+                                    Some(&trace_id),
+                                    sampled_execution,
+                                    Some(selected_target.module.as_str()),
+                                    true,
+                                )
+                                .await
+                                {
+                                    Ok(result) => {
+                                        let fuel_consumed = result.fuel_consumed;
+                                        (guest_response_into_response(result), fuel_consumed)
+                                    }
+                                    Err((status, message)) => {
+                                        ((status, message).into_response(), None)
+                                    }
+                                },
                             }
                         }
                     }
@@ -1883,17 +1910,41 @@ pub(crate) async fn faas_handler(
         },
     };
 
-    telemetry::record_event(
-        &state.telemetry,
-        TelemetryEvent::RequestEnd {
+    // A streaming response's body may still be draining long after this
+    // function returns it, so its `active_requests` slot and `RequestEnd`
+    // duration must track the body's own lifetime rather than "the handler
+    // returned" — see `TelemetryCompletionBody`. Buffered responses have no
+    // such lag: the whole body is already known here, so `RequestEnd` is
+    // recorded immediately, as it always has been.
+    if response
+        .extensions()
+        .get::<StreamingResponseMarker>()
+        .is_some()
+    {
+        let completion = RequestCompletion::new(
+            state.telemetry.clone(),
+            active_request,
             trace_id,
-            status: response.status().as_u16(),
+            response.status().as_u16(),
             fuel_consumed,
-            timestamp: Instant::now(),
-        },
-    );
-
-    response
+        );
+        let (parts, body) = response.into_parts();
+        Response::from_parts(
+            parts,
+            Body::new(TelemetryCompletionBody::new(body, completion)),
+        )
+    } else {
+        telemetry::record_event(
+            &state.telemetry,
+            TelemetryEvent::RequestEnd {
+                trace_id,
+                status: response.status().as_u16(),
+                fuel_consumed,
+                timestamp: Instant::now(),
+            },
+        );
+        response
+    }
 }
 
 fn is_reserved_system_path(path: &str) -> bool {

--- a/core-host/src/host_core/runtime_types.rs
+++ b/core-host/src/host_core/runtime_types.rs
@@ -615,6 +615,14 @@ pub(crate) struct GuestResponseBody {
     pub(crate) _completion_guard: Option<RouteResponseGuard>,
 }
 
+/// Marks a `Response` built with a genuinely streaming body (as opposed to a
+/// buffered one) via `Response::extensions`, so `faas_handler` can defer its
+/// telemetry completion to the body's own lifetime without threading a
+/// `bool` through every branch that can produce a response. Extensions never
+/// reach the wire, so this never leaks past the process.
+#[derive(Clone, Copy)]
+pub(crate) struct StreamingResponseMarker;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct UdpResponseDatagram {
     pub(crate) target: SocketAddr,
@@ -854,6 +862,58 @@ impl hyper::body::Body for GuestResponseBody {
             hint.set_exact(0);
         }
         hint
+    }
+}
+
+/// Wraps a streaming response body so its owning request's telemetry
+/// (`active_requests` gauge, `TelemetryEvent::RequestEnd`) stays live for as
+/// long as the body itself does, instead of being torn down the moment
+/// `faas_handler` returns a `Response` with headers ready. Applies uniformly
+/// to every streaming response shape — the `x-tachyon-route-override`
+/// direct-streaming path, the ai-inference SSE guest-streaming path, and the
+/// peer-overflow streaming paths — so all three report true request duration
+/// and keep the load-shedding gauge elevated for the stream's whole
+/// lifetime, not just until headers are sent.
+///
+/// `completion` finishes (records `RequestEnd`, releases the
+/// `active_requests` slot) either here, once `poll_frame` observes
+/// end-of-stream, or via its own `Drop` if the body is dropped first (client
+/// disconnects mid-stream) — whichever happens first, exactly once.
+pub(crate) struct TelemetryCompletionBody {
+    inner: Body,
+    completion: Option<RequestCompletion>,
+}
+
+impl TelemetryCompletionBody {
+    pub(crate) fn new(inner: Body, completion: RequestCompletion) -> Self {
+        Self {
+            inner,
+            completion: Some(completion),
+        }
+    }
+}
+
+impl hyper::body::Body for TelemetryCompletionBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        let poll = Pin::new(&mut self.inner).poll_frame(cx);
+        if let Poll::Ready(None) = &poll {
+            self.completion.take();
+        }
+        poll
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
     }
 }
 

--- a/core-host/src/host_core/tests/telemetry_and_l4.rs
+++ b/core-host/src/host_core/tests/telemetry_and_l4.rs
@@ -172,6 +172,153 @@ async fn router_skips_telemetry_export_for_unsampled_requests() {
     );
 }
 
+// Regression test for #400: `faas_handler`'s `active_requests` gauge and
+// `TelemetryEvent::RequestEnd` used to be scoped to "the handler returned a
+// `Response`," not "the response body finished draining." For a streaming
+// response (here: the `x-tachyon-route-override` direct-streaming path
+// forwarding to a slow peer) that meant both dropped the instant headers
+// were ready, even though the peer kept sending chunks for a while after.
+// `TelemetryCompletionBody` fixes this by deferring both to the body's own
+// completion. This drives a real streaming response end to end through
+// `faas_handler` and asserts `active_requests` stays elevated across two
+// separate chunks and only drops — and `RequestEnd` only fires — once the
+// peer's stream actually ends.
+#[tokio::test]
+async fn streaming_override_response_keeps_active_requests_elevated_until_stream_ends() {
+    use axum::{body::Body as AxumBody, response::Response as AxumResponse, routing::any, Router};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    async fn drip_two_chunks_then_end() -> AxumResponse {
+        let (sender, receiver) = mpsc::channel::<std::result::Result<Bytes, StreamForwardError>>(1);
+        tokio::spawn(async move {
+            let _ = sender.send(Ok(Bytes::from_static(b"chunk-1"))).await;
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let _ = sender.send(Ok(Bytes::from_static(b"chunk-2"))).await;
+            // Dropping `sender` here ends the stream cleanly.
+        });
+        AxumResponse::builder()
+            .status(StatusCode::OK)
+            .body(AxumBody::new(TimeoutBoundedStreamBody { receiver }))
+            .expect("peer response should build")
+    }
+
+    let peer_app = Router::new().route(DEFAULT_ROUTE, any(drip_two_chunks_then_end));
+    let peer_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("peer listener should bind");
+    let peer_address = peer_listener
+        .local_addr()
+        .expect("peer listener should expose an address");
+    let peer_server = tokio::spawn(async move {
+        axum::serve(peer_listener, peer_app)
+            .await
+            .expect("peer app should stay up");
+    });
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let telemetry = telemetry::init_test_telemetry_with_emitter({
+        let captured = Arc::clone(&captured);
+        move |line| {
+            captured
+                .lock()
+                .expect("captured telemetry should not be poisoned")
+                .push(line);
+            true
+        }
+    });
+    let telemetry_handle = telemetry.clone();
+
+    let config = validate_integrity_config(IntegrityConfig {
+        telemetry_sample_rate: 1.0,
+        ..IntegrityConfig::default_sealed()
+    })
+    .expect("config should validate");
+    let state = build_test_state(config, telemetry);
+    update_control_plane_route_override(
+        state.route_overrides.as_ref(),
+        &state.peer_capabilities,
+        DEFAULT_ROUTE,
+        &format!("http://{peer_address}{DEFAULT_ROUTE}"),
+    )
+    .expect("route override should install");
+
+    assert_eq!(telemetry::active_requests(&telemetry_handle), 0);
+
+    let app = build_app(state);
+    let response = app
+        .oneshot(
+            Request::get(DEFAULT_ROUTE)
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Headers are ready, but the peer is still mid-stream: the old behavior
+    // would already have dropped the slot here.
+    assert_eq!(
+        telemetry::active_requests(&telemetry_handle),
+        1,
+        "active_requests must stay elevated once headers are ready but the body is still streaming"
+    );
+
+    let mut body = response.into_body();
+    let first = tokio::time::timeout(Duration::from_secs(5), body.frame())
+        .await
+        .expect("first chunk should arrive")
+        .expect("body should yield a frame")
+        .expect("frame should not be an error");
+    assert_eq!(&first.into_data().expect("data frame")[..], b"chunk-1");
+    assert_eq!(
+        telemetry::active_requests(&telemetry_handle),
+        1,
+        "active_requests must stay elevated between chunks"
+    );
+
+    let second = tokio::time::timeout(Duration::from_secs(5), body.frame())
+        .await
+        .expect("second chunk should arrive")
+        .expect("body should yield a frame")
+        .expect("frame should not be an error");
+    assert_eq!(&second.into_data().expect("data frame")[..], b"chunk-2");
+
+    let end = tokio::time::timeout(Duration::from_secs(5), body.frame())
+        .await
+        .expect("stream should end promptly after the second chunk");
+    assert!(end.is_none(), "stream should end after the second chunk");
+
+    assert_eq!(
+        telemetry::active_requests(&telemetry_handle),
+        0,
+        "active_requests must drop back to 0 once the stream actually ends"
+    );
+
+    let line = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if let Some(line) = captured
+                .lock()
+                .expect("captured telemetry should not be poisoned")
+                .first()
+                .cloned()
+            {
+                break line;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("RequestEnd telemetry line should be emitted once the stream ends");
+    let record: serde_json::Value =
+        serde_json::from_str(&line).expect("telemetry output should be valid JSON");
+    assert_eq!(record["status"], 200);
+
+    peer_server.abort();
+}
+
 #[tokio::test]
 async fn metering_outbox_retry_drain_removes_successfully_exported_records() {
     let state = build_test_state(

--- a/core-host/src/network/mod.rs
+++ b/core-host/src/network/mod.rs
@@ -1095,6 +1095,7 @@ pub(crate) async fn handle_streaming_http_request(
     if let Err(e) = insert_guest_fields(response.headers_mut(), &guest_headers, "response header") {
         return Err((StatusCode::INTERNAL_SERVER_ERROR, e));
     }
+    response.extensions_mut().insert(StreamingResponseMarker);
     Ok(response)
 }
 

--- a/core-host/src/telemetry/mod.rs
+++ b/core-host/src/telemetry/mod.rs
@@ -190,6 +190,64 @@ pub(crate) fn active_requests(handle: &TelemetryHandle) -> usize {
     handle.snapshot.active_requests.load(Ordering::Relaxed)
 }
 
+/// Carries a request's `active_requests` slot and its final `RequestEnd`
+/// event past the point where the handler function returns a `Response`,
+/// so a caller can defer both until whatever actually drains the response
+/// body — not just until headers are ready — finishes or is dropped.
+///
+/// Streaming responses (proxied SSE, mesh-overflow redirects, etc.) hand
+/// this to a body wrapper that calls `finish()` once the underlying body
+/// reports end-of-stream; buffered responses have no need for it and keep
+/// recording `RequestEnd` immediately, as before. `finish()` is idempotent
+/// and also runs on `Drop`, so a body dropped mid-stream (client hang-up)
+/// still releases the slot and emits the event instead of leaking both.
+pub(crate) struct RequestCompletion {
+    telemetry: TelemetryHandle,
+    trace_id: Option<String>,
+    status: u16,
+    fuel_consumed: Option<u64>,
+    active_request: Option<ActiveRequestGuard>,
+}
+
+impl RequestCompletion {
+    pub(crate) fn new(
+        telemetry: TelemetryHandle,
+        active_request: ActiveRequestGuard,
+        trace_id: String,
+        status: u16,
+        fuel_consumed: Option<u64>,
+    ) -> Self {
+        Self {
+            telemetry,
+            trace_id: Some(trace_id),
+            status,
+            fuel_consumed,
+            active_request: Some(active_request),
+        }
+    }
+
+    fn finish(&mut self) {
+        if let Some(trace_id) = self.trace_id.take() {
+            record_event(
+                &self.telemetry,
+                TelemetryEvent::RequestEnd {
+                    trace_id,
+                    status: self.status,
+                    fuel_consumed: self.fuel_consumed,
+                    timestamp: Instant::now(),
+                },
+            );
+        }
+        self.active_request = None;
+    }
+}
+
+impl Drop for RequestCompletion {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
 pub(crate) fn snapshot(handle: &TelemetryHandle) -> TelemetrySnapshot {
     handle.snapshot.snapshot()
 }


### PR DESCRIPTION
faas_handler's active_requests gauge and RequestEnd duration were both
scoped to "the handler returned a Response," which for a streaming body
means "headers are ready" rather than "the body finished draining." Total
duration under-reported streaming requests, and should_shed_system_route's
load-shedding gauge dropped back down the instant headers were sent even
though the stream kept running.

Introduce RequestCompletion (telemetry) and TelemetryCompletionBody
(host_core), which move the active-request guard and RequestEnd emission
onto the response body's own lifetime instead of the handler's return.
Response::extensions carries a StreamingResponseMarker so faas_handler can
tell, after the fact, which of its many branches produced a genuinely
streaming body (build_guest_response, forward_request_to_override, and
network::handle_streaming_http_request) without threading a bool through
every arm. Buffered responses are untouched: RequestEnd still fires
immediately, as before.

Also turns the two "early return on SSE Accept" branches in faas_handler
into ordinary match arms so their response flows through the same
completion logic as every other path, instead of skipping RequestEnd
entirely.

Fixes #400.