### PR TITLE
[codex] Configure compatible Renovate dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,9 +4351,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,12 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["tokenizers"],
       "allowedVersions": "<0.23"
+    },
+    {
+      "description": "object_store is pinned through the workspace's git patch; Renovate cannot update the crates.io version until that patch is removed or moved to a matching revision.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["object_store"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,22 @@
       "matchCurrentVersion": "<0.11",
       "groupName": "rustcrypto-next-gen",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Wasmtime crates expose shared Rust types, so their major versions must move together. Keeping wasmtime, wasmtime-wasi, and wasmtime-wasi-nn aligned prevents duplicate-version type mismatches.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "wasmtime",
+        "wasmtime-wasi",
+        "wasmtime-wasi-nn"
+      ],
+      "groupName": "wasmtime ecosystem"
+    },
+    {
+      "description": "Candle currently requires tokenizers 0.22: tokenizers 0.23 creates incompatible Tokenizer types in Candle's incremental decoder.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["tokenizers"],
+      "allowedVersions": "<0.23"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- group the Wasmtime ecosystem so its shared types stay version-aligned
- prevent tokenizers 0.23 until Candle supports it
- ignore object_store updates while the workspace git patch pins a different revision
- update h2 to 0.4.16 for RUSTSEC-2026-0258

## Root cause
Independent Wasmtime upgrades introduced incompatible 46/47 types, while tokenizers 0.23 is incompatible with the Candle version in this workspace. Renovate also cannot generate Cargo.lock for object_store while the git patch remains pinned. Cargo audit reported the h2 empty-DATA-frames advisory against 0.4.14.

## Validation
- Parsed renovate.json with PowerShell ConvertFrom-Json
- Ran git diff --check
- Ran cargo metadata --locked --no-deps
- Started cargo check -p core-host; it exceeded the interactive timeout without emitting an error.